### PR TITLE
ci: Use cache in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@2.2.4
+        uses: pnpm/action-setup@v2.2.4
         with:
           version: 7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@2.2.4
+        with:
+          version: 7
+
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2.2.1


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Overview

Updated `ci.yml` to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data). `setup-node@v3` or newer has caching **built-in**.

### About caching workflow dependencies
Jobs on GitHub-hosted runners start in a clean virtual environment and **must download dependencies each time**, causing increased network utilization, longer runtime, and increased cost. To help speed up the time it takes to recreate files like dependencies, GitHub can cache files that frequently use in workflows.

### Solutions
Node.js projects can run faster on GitHub Actions by enabling dependency caching on the [setup-node](https://github.com/actions/setup-node) action. 

### AS-IS

```yml
- name: Setup node
  uses: actions/setup-node@v2
  with:
    node-version: '16'

- name: Setup pnpm
  uses: pnpm/action-setup@2.2.1
  with:
    version: 7
    run_install: |
      - args: [--frozen-lockfile]
```

### TO-BE

```yml
- name: Setup pnpm
  uses: pnpm/action-setup@2.2.4
  with:
    version: 7

- name: Setup node
  uses: actions/setup-node@v3
  with:
    node-version: '16'
    cache: 'pnpm'

 - name: Install dependencies
   run: pnpm install --frozen-lockfile
```

> It’s literally a one line change to pass the `cache: 'pnpm'` input parameter.

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data)
- [https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/nestjs-aop/blob/main/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
