### PR TITLE
feat: Allow more than one AopDecorator to be applied to one method (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ export class CacheModule {}
 
 #### 5. Create decorator that marks metadata of LazyDecorator
 ```typescript
-export const Cache = (options: CacheOptions) => SetMetadata(CACHE_DECORATOR, options);
+export const Cache = createDecorator<CacheOptions>(CACHE_DECORATOR)
 ```
 
 #### 6. Use it!

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@toss/nestjs-aop",
-  "version": "1.0.3",
+  "version": "2.0.0-next",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "esm/index.js",
   "license": "ISC",
   "engines": {
     "node": ">=16",
-    "pnpm": "7.x"
+    "pnpm": "^7"
   },
   "scripts": {
     "test": "jest --maxWorkers 4",
@@ -56,6 +56,7 @@
     "toss-nestjs"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "next"
   }
 }

--- a/src/__test__/aop.module.test.ts
+++ b/src/__test__/aop.module.test.ts
@@ -2,8 +2,8 @@ import 'reflect-metadata';
 
 import { FastifyAdapter } from '@nestjs/platform-fastify';
 import { Test } from '@nestjs/testing';
-import { FooModule, FooService } from './fixture/foo';
 import { AopModule } from '../aop.module';
+import { FooModule, FooService } from './fixture/foo';
 
 describe('AopModule', () => {
   it('Lazy decoder overwrites the original function', async () => {
@@ -28,5 +28,18 @@ describe('AopModule', () => {
     await app.init();
     const fooService = app.get(FooService);
     expect(Object.getPrototypeOf(fooService.foo)).toBe(fooService.originalFoo);
+  });
+
+  it('Decorator order must be guaranteed', async () => {
+    const module = await Test.createTestingModule({
+      imports: [AopModule, FooModule],
+    }).compile();
+
+    const app = module.createNestApplication(new FastifyAdapter());
+    await app.init();
+    const fooService = app.get(FooService);
+    expect(fooService.multipleDecorated('abc', 1)).toMatchInlineSnapshot(
+      `"abc1sample{\\"options\\":\\"options3\\"}sample{\\"options\\":\\"options2\\"}sample{\\"options\\":\\"options1\\"}"`,
+    );
   });
 });

--- a/src/__test__/fixture/foo/foo.decorator.ts
+++ b/src/__test__/fixture/foo/foo.decorator.ts
@@ -1,5 +1,5 @@
-import { SetMetadata } from '@nestjs/common';
 import { Aspect } from '../../../aspect';
+import { createDecorator } from '../../../create-decorator';
 import { LazyDecorator, WrapParams } from '../../../lazy-decorator';
 import { SampleService } from '../sample';
 import { FooService } from './foo.service';
@@ -9,7 +9,7 @@ export const FOO = Symbol('FOO');
 type FooOptions = {
   options: string;
 };
-export const Foo = (options: FooOptions) => SetMetadata(FOO, options);
+export const Foo = createDecorator<FooOptions>(FOO);
 
 @Aspect(FOO)
 export class FooDecorator implements LazyDecorator<FooService['foo'], FooOptions> {

--- a/src/__test__/fixture/foo/foo.service.ts
+++ b/src/__test__/fixture/foo/foo.service.ts
@@ -12,4 +12,11 @@ export class FooService {
   foo(arg1: string, arg2: number) {
     return arg1 + arg2;
   }
+
+  @Foo({ options: 'options1' })
+  @Foo({ options: 'options2' })
+  @Foo({ options: 'options3' })
+  multipleDecorated(arg1: string, arg2: number) {
+    return arg1 + arg2;
+  }
 }

--- a/src/auto-aspect-executor.ts
+++ b/src/auto-aspect-executor.ts
@@ -34,18 +34,21 @@ export class AutoAspectExecutor implements OnModuleInit {
             lazyDecorators.forEach((lazyDecorator) => {
               const metadataKey = this.reflector.get(ASPECT, lazyDecorator.constructor);
 
-              const metadata = this.reflector.get(metadataKey, instance[methodName]);
-              if (!metadata) {
+              const metadataList: unknown[] = this.reflector.get(metadataKey, instance[methodName]);
+              if (!metadataList) {
                 return;
               }
-              const wrappedMethod = lazyDecorator.wrap({
-                instance,
-                methodName,
-                method: instance[methodName].bind(instance),
-                metadata,
-              });
-              Object.setPrototypeOf(wrappedMethod, instance[methodName]);
-              instance[methodName] = wrappedMethod;
+
+              for (const metadata of metadataList) {
+                const wrappedMethod = lazyDecorator.wrap({
+                  instance,
+                  methodName,
+                  method: instance[methodName].bind(instance),
+                  metadata,
+                });
+                Object.setPrototypeOf(wrappedMethod, instance[methodName]);
+                instance[methodName] = wrappedMethod;
+              }
             }),
         );
       });

--- a/src/create-decorator.ts
+++ b/src/create-decorator.ts
@@ -1,0 +1,5 @@
+import { AddMetadata } from './utils';
+
+export function createDecorator<T = void>(metadataKey: any) {
+  return (options: T) => AddMetadata(metadataKey, options);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './aop.module';
 export * from './aspect';
+export * from './create-decorator';
 export * from './lazy-decorator';

--- a/src/utils/add-metadata.ts
+++ b/src/utils/add-metadata.ts
@@ -1,0 +1,19 @@
+export const AddMetadata = <K = string, V = any>(
+  metadataKey: K,
+  metadataValue: V,
+): MethodDecorator => {
+  const decoratorFactory = (
+    _: any,
+    __: string | symbol,
+    descriptor: PropertyDescriptor,
+  ): TypedPropertyDescriptor<any> => {
+    if (!Reflect.hasMetadata(metadataKey, descriptor.value)) {
+      Reflect.defineMetadata(metadataKey, [], descriptor.value);
+    }
+    const metadataValues: V[] = Reflect.getMetadata(metadataKey, descriptor.value);
+    metadataValues.push(metadataValue);
+    return descriptor;
+  };
+  decoratorFactory.KEY = metadataKey;
+  return decoratorFactory;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './add-metadata';


### PR DESCRIPTION
## Overview
I modified #7 to apply same aop decorators using createDecorator function.
`createDecorator` adds metadata to the array without overwriting it.
Duplicate application is possible because AopExecutor receives all recorded metadata and executes wrap.

