### PR TITLE
feat: Allow more than one AopDecorator to be applied to one method (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ export class CacheModule {}
 
 #### 5. Create decorator that marks metadata of LazyDecorator
 ```typescript
-export const Cache = (options: CacheOptions) => SetMetadata(CACHE_DECORATOR, options);
+export const Cache = createDecorator<CacheOptions>(CACHE_DECORATOR)
 ```
 
 #### 6. Use it!

--- a/src/__test__/aop.module.test.ts
+++ b/src/__test__/aop.module.test.ts
@@ -14,9 +14,7 @@ describe('AopModule', () => {
     const app = module.createNestApplication(new FastifyAdapter());
     await app.init();
     const fooService = app.get(FooService);
-    expect(fooService.foo('abc', 1)).toMatchInlineSnapshot(
-      `"abc1sample{\\"options\\":\\"options\\"}"`,
-    );
+    expect(fooService.foo('abc', 1)).toMatchInlineSnapshot(`"abc1:sample:options"`);
   });
 
   it('Prototype of the overwritten function must be the original function', async () => {
@@ -38,8 +36,9 @@ describe('AopModule', () => {
     const app = module.createNestApplication(new FastifyAdapter());
     await app.init();
     const fooService = app.get(FooService);
+    // TODO: https://github.com/toss/nestjs-aop/issues/7
     expect(fooService.multipleDecorated('abc', 1)).toMatchInlineSnapshot(
-      `"abc1sample{\\"options\\":\\"options3\\"}sample{\\"options\\":\\"options2\\"}sample{\\"options\\":\\"options1\\"}"`,
+      `"abc1:4:2:sample:5:sample:3:sample:1"`,
     );
   });
 });

--- a/src/__test__/aop.module.test.ts
+++ b/src/__test__/aop.module.test.ts
@@ -2,8 +2,8 @@ import 'reflect-metadata';
 
 import { FastifyAdapter } from '@nestjs/platform-fastify';
 import { Test } from '@nestjs/testing';
-import { FooModule, FooService } from './fixture/foo';
 import { AopModule } from '../aop.module';
+import { FooModule, FooService } from './fixture/foo';
 
 describe('AopModule', () => {
   it('Lazy decoder overwrites the original function', async () => {
@@ -28,5 +28,18 @@ describe('AopModule', () => {
     await app.init();
     const fooService = app.get(FooService);
     expect(Object.getPrototypeOf(fooService.foo)).toBe(fooService.originalFoo);
+  });
+
+  it('Decorator order must be guaranteed', async () => {
+    const module = await Test.createTestingModule({
+      imports: [AopModule, FooModule],
+    }).compile();
+
+    const app = module.createNestApplication(new FastifyAdapter());
+    await app.init();
+    const fooService = app.get(FooService);
+    expect(fooService.multipleDecorated('abc', 1)).toMatchInlineSnapshot(
+      `"abc1sample{\\"options\\":\\"options3\\"}sample{\\"options\\":\\"options2\\"}sample{\\"options\\":\\"options1\\"}"`,
+    );
   });
 });

--- a/src/__test__/aop.module.test.ts
+++ b/src/__test__/aop.module.test.ts
@@ -14,7 +14,7 @@ describe('AopModule', () => {
     const app = module.createNestApplication(new FastifyAdapter());
     await app.init();
     const fooService = app.get(FooService);
-    expect(fooService.foo('abc', 1)).toMatchInlineSnapshot(`"abc1:sample:options"`);
+    expect(fooService.foo('original', 0)).toMatchInlineSnapshot(`"original0:dependency_options"`);
   });
 
   it('Prototype of the overwritten function must be the original function', async () => {
@@ -37,8 +37,8 @@ describe('AopModule', () => {
     await app.init();
     const fooService = app.get(FooService);
     // TODO: https://github.com/toss/nestjs-aop/issues/7
-    expect(fooService.multipleDecorated('abc', 1)).toMatchInlineSnapshot(
-      `"abc1:4:2:sample:5:sample:3:sample:1"`,
+    expect(fooService.multipleDecorated('original', 0)).toMatchInlineSnapshot(
+      `"original0:ts_decroator_4:ts_decroator_2:dependency_5:dependency_3:dependency_1"`,
     );
   });
 });

--- a/src/__test__/fixture/foo/foo.decorator.ts
+++ b/src/__test__/fixture/foo/foo.decorator.ts
@@ -1,5 +1,5 @@
-import { SetMetadata } from '@nestjs/common';
 import { Aspect } from '../../../aspect';
+import { createDecorator } from '../../../create-decorator';
 import { LazyDecorator, WrapParams } from '../../../lazy-decorator';
 import { SampleService } from '../sample';
 import { FooService } from './foo.service';
@@ -9,7 +9,7 @@ export const FOO = Symbol('FOO');
 type FooOptions = {
   options: string;
 };
-export const Foo = (options: FooOptions) => SetMetadata(FOO, options);
+export const Foo = createDecorator<FooOptions>(FOO);
 
 @Aspect(FOO)
 export class FooDecorator implements LazyDecorator<FooService['foo'], FooOptions> {

--- a/src/__test__/fixture/foo/foo.decorator.ts
+++ b/src/__test__/fixture/foo/foo.decorator.ts
@@ -20,7 +20,17 @@ export class FooDecorator implements LazyDecorator<FooService['foo'], FooOptions
       const originResult = method(arg1, arg2);
       const sample = this.sampleService.sample();
 
-      return originResult + sample + JSON.stringify(options);
+      return originResult + ':' + sample + ':' + options.options;
     };
   }
 }
+
+export const NotAopFoo = (options: FooOptions): MethodDecorator => {
+  return (_: any, __: string | symbol, descriptor: PropertyDescriptor) => {
+    const originMethod = descriptor.value;
+    descriptor.value = function (arg1: string, arg2: number) {
+      return originMethod.call(this, arg1, arg2) + ':' + options.options;
+    };
+    Object.setPrototypeOf(descriptor.value, originMethod);
+  };
+};

--- a/src/__test__/fixture/foo/foo.decorator.ts
+++ b/src/__test__/fixture/foo/foo.decorator.ts
@@ -20,7 +20,7 @@ export class FooDecorator implements LazyDecorator<FooService['foo'], FooOptions
       const originResult = method(arg1, arg2);
       const sample = this.sampleService.sample();
 
-      return originResult + ':' + sample + ':' + options.options;
+      return originResult + ':' + sample + '_' + options.options;
     };
   }
 }
@@ -29,7 +29,7 @@ export const NotAopFoo = (options: FooOptions): MethodDecorator => {
   return (_: any, __: string | symbol, descriptor: PropertyDescriptor) => {
     const originMethod = descriptor.value;
     descriptor.value = function (arg1: string, arg2: number) {
-      return originMethod.call(this, arg1, arg2) + ':' + options.options;
+      return originMethod.call(this, arg1, arg2) + ':ts_decroator_' + options.options;
     };
     Object.setPrototypeOf(descriptor.value, originMethod);
   };

--- a/src/__test__/fixture/foo/foo.service.ts
+++ b/src/__test__/fixture/foo/foo.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Foo } from './foo.decorator';
+import { Foo, NotAopFoo } from './foo.decorator';
 
 @Injectable()
 export class FooService {
@@ -13,9 +13,11 @@ export class FooService {
     return arg1 + arg2;
   }
 
-  @Foo({ options: 'options1' })
-  @Foo({ options: 'options2' })
-  @Foo({ options: 'options3' })
+  @Foo({ options: '1' })
+  @NotAopFoo({ options: '2' })
+  @Foo({ options: '3' })
+  @NotAopFoo({ options: '4' })
+  @Foo({ options: '5' })
   multipleDecorated(arg1: string, arg2: number) {
     return arg1 + arg2;
   }

--- a/src/__test__/fixture/foo/foo.service.ts
+++ b/src/__test__/fixture/foo/foo.service.ts
@@ -12,4 +12,11 @@ export class FooService {
   foo(arg1: string, arg2: number) {
     return arg1 + arg2;
   }
+
+  @Foo({ options: 'options1' })
+  @Foo({ options: 'options2' })
+  @Foo({ options: 'options3' })
+  multipleDecorated(arg1: string, arg2: number) {
+    return arg1 + arg2;
+  }
 }

--- a/src/__test__/fixture/sample/sample.service.ts
+++ b/src/__test__/fixture/sample/sample.service.ts
@@ -3,6 +3,6 @@ import { Injectable } from '@nestjs/common';
 @Injectable()
 export class SampleService {
   sample() {
-    return 'sample';
+    return 'dependency';
   }
 }

--- a/src/auto-aspect-executor.ts
+++ b/src/auto-aspect-executor.ts
@@ -34,18 +34,21 @@ export class AutoAspectExecutor implements OnModuleInit {
             lazyDecorators.forEach((lazyDecorator) => {
               const metadataKey = this.reflector.get(ASPECT, lazyDecorator.constructor);
 
-              const metadata = this.reflector.get(metadataKey, instance[methodName]);
-              if (!metadata) {
+              const metadataList: unknown[] = this.reflector.get(metadataKey, instance[methodName]);
+              if (!metadataList) {
                 return;
               }
-              const wrappedMethod = lazyDecorator.wrap({
-                instance,
-                methodName,
-                method: instance[methodName].bind(instance),
-                metadata,
-              });
-              Object.setPrototypeOf(wrappedMethod, instance[methodName]);
-              instance[methodName] = wrappedMethod;
+
+              for (const metadata of metadataList) {
+                const wrappedMethod = lazyDecorator.wrap({
+                  instance,
+                  methodName,
+                  method: instance[methodName].bind(instance),
+                  metadata,
+                });
+                Object.setPrototypeOf(wrappedMethod, instance[methodName]);
+                instance[methodName] = wrappedMethod;
+              }
             }),
         );
       });

--- a/src/create-decorator.ts
+++ b/src/create-decorator.ts
@@ -1,0 +1,5 @@
+import { AddMetadata } from './utils';
+
+export function createDecorator<T = void>(metadataKey: any) {
+  return (options: T) => AddMetadata(metadataKey, options);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './aop.module';
 export * from './aspect';
+export * from './create-decorator';
 export * from './lazy-decorator';

--- a/src/utils/add-metadata.ts
+++ b/src/utils/add-metadata.ts
@@ -1,0 +1,19 @@
+export const AddMetadata = <K = string, V = any>(
+  metadataKey: K,
+  metadataValue: V,
+): MethodDecorator => {
+  const decoratorFactory = (
+    _: any,
+    __: string | symbol,
+    descriptor: PropertyDescriptor,
+  ): TypedPropertyDescriptor<any> => {
+    if (!Reflect.hasMetadata(metadataKey, descriptor.value)) {
+      Reflect.defineMetadata(metadataKey, [], descriptor.value);
+    }
+    const metadataValues: V[] = Reflect.getMetadata(metadataKey, descriptor.value);
+    metadataValues.push(metadataValue);
+    return descriptor;
+  };
+  decoratorFactory.KEY = metadataKey;
+  return decoratorFactory;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './add-metadata';


### PR DESCRIPTION
## Overview
I modified #6 to apply same aop decorators using createDecorator function.
`createDecorator` adds metadata to the array without overwriting it.
Duplicate application is possible because AopExecutor receives all recorded metadata and executes wrap.

