### PR TITLE
feat: #7 Ensure the order of decorating the aop decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ export class CacheModule {}
 
 #### 5. Create decorator that marks metadata of LazyDecorator
 ```typescript
-export const Cache = createDecorator<CacheOptions>(CACHE_DECORATOR)
+export const Cache = (options: CacheOptions) => createDecorator<CacheOptions>(CACHE_DECORATOR, options)
 ```
 
 #### 6. Use it!

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ export const CACHE_DECORATOR = Symbol('CACHE_DECORATOR');
 ```
 
 #### 3. Implement LazyDecorator using nestjs provider
+`metadata` is the second parameter of createDecorator.
+
 ```typescript
 @Aspect(CACHE_DECORATOR)
 export class CacheDecorator implements LazyDecorator<any, CacheOptions> {
@@ -91,6 +93,8 @@ export class CacheModule {}
 ```
 
 #### 5. Create decorator that marks metadata of LazyDecorator
+`options` can be obtained from the warp method and used.
+
 ```typescript
 export const Cache = (options: CacheOptions) => createDecorator<CacheOptions>(CACHE_DECORATOR, options)
 ```

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.5.6"
   },
+  "dependencies": {
+    "ramda": "^0.28.0"
+  },
   "devDependencies": {
     "@nestjs/common": "^8.4.7",
     "@nestjs/core": "^8.4.7",
@@ -31,6 +34,7 @@
     "@nestjs/testing": "^8.4.7",
     "@types/jest": "^28.1.8",
     "@types/node": "^16.18.6",
+    "@types/ramda": "^0.28.23",
     "@typescript-eslint/eslint-plugin": "~5.42.1",
     "@typescript-eslint/parser": "~5.42.1",
     "eslint": "8.22.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "src"
   ],
   "peerDependencies": {
-    "@nestjs/common": "^8.0.0",
-    "@nestjs/core": "^8.0.0",
+    "@nestjs/common": "^8 || ^9",
+    "@nestjs/core": "^^8 || ^9",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.5.6"
   },
@@ -28,10 +28,10 @@
     "ramda": "^0.28.0"
   },
   "devDependencies": {
-    "@nestjs/common": "^8.4.7",
-    "@nestjs/core": "^8.4.7",
-    "@nestjs/platform-fastify": "^8.4.7",
-    "@nestjs/testing": "^8.4.7",
+    "@nestjs/common": "^9",
+    "@nestjs/core": "^9",
+    "@nestjs/platform-fastify": "^9",
+    "@nestjs/testing": "^9",
     "@types/jest": "^28.1.8",
     "@types/node": "^16.18.6",
     "@types/ramda": "^0.28.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,10 +1,10 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@nestjs/common': ^8.4.7
-  '@nestjs/core': ^8.4.7
-  '@nestjs/platform-fastify': ^8.4.7
-  '@nestjs/testing': ^8.4.7
+  '@nestjs/common': ^9
+  '@nestjs/core': ^9
+  '@nestjs/platform-fastify': ^9
+  '@nestjs/testing': ^9
   '@types/jest': ^28.1.8
   '@types/node': ^16.18.6
   '@types/ramda': ^0.28.23
@@ -24,10 +24,10 @@ dependencies:
   ramda: 0.28.0
 
 devDependencies:
-  '@nestjs/common': 8.4.7_whg6pvy6vwu66ypq7idiq2suxq
-  '@nestjs/core': 8.4.7_4vqalbqpgkpmtxhfqdv2kx42sq
-  '@nestjs/platform-fastify': 8.4.7_7tsmhnugyerf5okgqzer2mfqme
-  '@nestjs/testing': 8.4.7_7tsmhnugyerf5okgqzer2mfqme
+  '@nestjs/common': 9.3.9_whg6pvy6vwu66ypq7idiq2suxq
+  '@nestjs/core': 9.3.9_6eenlv3uxu77azgl2iuo24dzau
+  '@nestjs/platform-fastify': 9.3.9_77foi4w27ghy47yutmnzv7krjy
+  '@nestjs/testing': 9.3.9_77foi4w27ghy47yutmnzv7krjy
   '@types/jest': 28.1.8
   '@types/node': 16.18.6
   '@types/ramda': 0.28.23
@@ -390,14 +390,48 @@ packages:
       - supports-color
     dev: true
 
-  /@fastify/ajv-compiler/1.1.0:
-    resolution: {integrity: sha512-gvCOUNpXsWrIQ3A4aXCLIdblL0tDq42BG/2Xw7oxbil9h11uow10ztS2GuFazNBfjbrsZ5nl+nPl5jDSjj5TSg==}
+  /@fastify/ajv-compiler/3.5.0:
+    resolution: {integrity: sha512-ebbEtlI7dxXF5ziNdr05mOY8NnDiPB1XvAlLHctRt/Rc+C3LCOVW5imUVX+mhvUhnNzmPBHewUkOFgGlCxgdAA==}
     dependencies:
-      ajv: 6.12.6
+      ajv: 8.11.2
+      ajv-formats: 2.1.1
+      fast-uri: 2.2.0
     dev: true
 
-  /@fastify/error/2.0.0:
-    resolution: {integrity: sha512-wI3fpfDT0t7p8E6dA2eTECzzOd+bZsZCJ2Hcv+Onn2b7ZwK3RwD27uW2QDaMtQhAfWQQP+WNK7nKf0twLsBf9w==}
+  /@fastify/cors/8.2.0:
+    resolution: {integrity: sha512-qDgwpmg6C4D0D3nh8MTMuRXWyEwPnDZDBODaJv90FP2o9ukbahJByW4FtrM5Bpod5KbTf1oIExBmpItbUTQmHg==}
+    dependencies:
+      fastify-plugin: 4.5.0
+      mnemonist: 0.39.5
+    dev: true
+
+  /@fastify/deepmerge/1.3.0:
+    resolution: {integrity: sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==}
+    dev: true
+
+  /@fastify/error/3.2.0:
+    resolution: {integrity: sha512-KAfcLa+CnknwVi5fWogrLXgidLic+GXnLjijXdpl8pvkvbXU5BGa37iZO9FGvsh9ZL4y+oFi5cbHBm5UOG+dmQ==}
+    dev: true
+
+  /@fastify/fast-json-stringify-compiler/4.2.0:
+    resolution: {integrity: sha512-ypZynRvXA3dibfPykQN3RB5wBdEUgSGgny8Qc6k163wYPLD4mEGEDkACp+00YmqkGvIm8D/xYoHajwyEdWD/eg==}
+    dependencies:
+      fast-json-stringify: 5.6.2
+    dev: true
+
+  /@fastify/formbody/7.4.0:
+    resolution: {integrity: sha512-H3C6h1GN56/SMrZS8N2vCT2cZr7mIHzBHzOBa5OPpjfB/D6FzP9mMpE02ZzrFX0ANeh0BAJdoXKOF2e7IbV+Og==}
+    dependencies:
+      fast-querystring: 1.1.1
+      fastify-plugin: 4.5.0
+    dev: true
+
+  /@fastify/middie/8.1.0:
+    resolution: {integrity: sha512-VvUCLfKx2j6KSnh8puT8QW7d5YNzi2fD/4HcFvRQ3a7sHlCo+qtfX2fqzFvNqnMVbNft7GX1JL5if/riUiXsyg==}
+    dependencies:
+      fastify-plugin: 4.5.0
+      path-to-regexp: 6.2.1
+      reusify: 1.0.4
     dev: true
 
   /@humanwhocodes/config-array/0.10.7:
@@ -687,10 +721,15 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
 
-  /@nestjs/common/8.4.7_whg6pvy6vwu66ypq7idiq2suxq:
-    resolution: {integrity: sha512-m/YsbcBal+gA5CFrDpqXqsSfylo+DIQrkFY3qhVIltsYRfu8ct8J9pqsTO6OPf3mvqdOpFGrV5sBjoyAzOBvsw==}
+  /@lukeed/csprng/1.0.1:
+    resolution: {integrity: sha512-uSvJdwQU5nK+Vdf6zxcWAY2A8r7uqe+gePwLWzJ+fsQehq18pc0I2hJKwypZ2aLM90+Er9u1xn4iLJPZ+xlL4g==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /@nestjs/common/9.3.9_whg6pvy6vwu66ypq7idiq2suxq:
+    resolution: {integrity: sha512-GshTD9Xz+wD2em6NyzU4NXw5IXMUmapgDgD+iuj6XL0258hvDwODmNk37mBBnZvTZlqER+krvIUKnS34etqF/A==}
     peerDependencies:
-      cache-manager: '*'
+      cache-manager: <=5
       class-transformer: '*'
       class-validator: '*'
       reflect-metadata: ^0.1.12
@@ -703,24 +742,21 @@ packages:
       class-validator:
         optional: true
     dependencies:
-      axios: 0.27.2
       iterare: 1.2.1
       reflect-metadata: 0.1.13
       rxjs: 7.6.0
-      tslib: 2.4.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
+      tslib: 2.5.0
+      uid: 2.0.1
     dev: true
 
-  /@nestjs/core/8.4.7_4vqalbqpgkpmtxhfqdv2kx42sq:
-    resolution: {integrity: sha512-XB9uexHqzr2xkPo6QSiQWJJttyYYLmvQ5My64cFvWFi7Wk2NIus0/xUNInwX3kmFWB6pF1ab5Y2ZBvWdPwGBhw==}
+  /@nestjs/core/9.3.9_6eenlv3uxu77azgl2iuo24dzau:
+    resolution: {integrity: sha512-9g1A1G9eirLXEpH21rc6dKb08zHc2+adhCRz8NW39hbejcsxxD72FApJzt4QBQAKvu862ixt/tdpStnFT7lOSw==}
     requiresBuild: true
     peerDependencies:
-      '@nestjs/common': ^8.0.0
-      '@nestjs/microservices': ^8.0.0
-      '@nestjs/platform-express': ^8.0.0
-      '@nestjs/websockets': ^8.0.0
+      '@nestjs/common': ^9.0.0
+      '@nestjs/microservices': ^9.0.0
+      '@nestjs/platform-express': ^9.0.0
+      '@nestjs/websockets': ^9.0.0
       reflect-metadata: ^0.1.12
       rxjs: ^7.1.0
     peerDependenciesMeta:
@@ -731,55 +767,61 @@ packages:
       '@nestjs/websockets':
         optional: true
     dependencies:
-      '@nestjs/common': 8.4.7_whg6pvy6vwu66ypq7idiq2suxq
+      '@nestjs/common': 9.3.9_whg6pvy6vwu66ypq7idiq2suxq
       '@nuxtjs/opencollective': 0.3.2
       fast-safe-stringify: 2.1.1
       iterare: 1.2.1
-      object-hash: 3.0.0
       path-to-regexp: 3.2.0
       reflect-metadata: 0.1.13
       rxjs: 7.6.0
-      tslib: 2.4.0
-      uuid: 8.3.2
+      tslib: 2.5.0
+      uid: 2.0.1
     transitivePeerDependencies:
       - encoding
     dev: true
 
-  /@nestjs/platform-fastify/8.4.7_7tsmhnugyerf5okgqzer2mfqme:
-    resolution: {integrity: sha512-3miB5AYQMlwTAC6W3HE3UTfsQF5RcCsellIEHhNKWN9jGA3C++zr24nEBzw61+Ca2fOG4+ccg4agtODn53d+UA==}
+  /@nestjs/platform-fastify/9.3.9_77foi4w27ghy47yutmnzv7krjy:
+    resolution: {integrity: sha512-+QZgd+1BDT5ZiISNWKGTsWKv6+RUYzOjOP5Iyo/hpljsGIq6GeXl90wP43FuqMp3+imVPu2AzmMa2CijT1iLXA==}
     peerDependencies:
-      '@nestjs/common': ^8.0.0
-      '@nestjs/core': ^8.0.0
+      '@fastify/static': ^6.0.0
+      '@fastify/view': ^7.0.0
+      '@nestjs/common': ^9.0.0
+      '@nestjs/core': ^9.0.0
+    peerDependenciesMeta:
+      '@fastify/static':
+        optional: true
+      '@fastify/view':
+        optional: true
     dependencies:
-      '@nestjs/common': 8.4.7_whg6pvy6vwu66ypq7idiq2suxq
-      '@nestjs/core': 8.4.7_4vqalbqpgkpmtxhfqdv2kx42sq
-      fastify: 3.29.0
-      fastify-cors: 6.1.0
-      fastify-formbody: 5.3.0
-      light-my-request: 5.0.0
-      middie: 6.1.0
+      '@fastify/cors': 8.2.0
+      '@fastify/formbody': 7.4.0
+      '@fastify/middie': 8.1.0
+      '@nestjs/common': 9.3.9_whg6pvy6vwu66ypq7idiq2suxq
+      '@nestjs/core': 9.3.9_6eenlv3uxu77azgl2iuo24dzau
+      fastify: 4.13.0
+      light-my-request: 5.8.0
       path-to-regexp: 3.2.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@nestjs/testing/8.4.7_7tsmhnugyerf5okgqzer2mfqme:
-    resolution: {integrity: sha512-aedpeJFicTBeiTCvJWUG45WMMS53f5eu8t2fXsfjsU1t+WdDJqYcZyrlCzA4dL1B7MfbqaTURdvuVVHTmJO8ag==}
+  /@nestjs/testing/9.3.9_77foi4w27ghy47yutmnzv7krjy:
+    resolution: {integrity: sha512-+mPvSVvSC2SAkYgZZv1mOI2xsdGc1pmq7/sem7iin/JDoFtlvoGSK+pfZHD3IV3EpYtq1v/8/5gi+UFH9yZnDg==}
     peerDependencies:
-      '@nestjs/common': ^8.0.0
-      '@nestjs/core': ^8.0.0
-      '@nestjs/microservices': ^8.0.0
-      '@nestjs/platform-express': ^8.0.0
+      '@nestjs/common': ^9.0.0
+      '@nestjs/core': ^9.0.0
+      '@nestjs/microservices': ^9.0.0
+      '@nestjs/platform-express': ^9.0.0
     peerDependenciesMeta:
       '@nestjs/microservices':
         optional: true
       '@nestjs/platform-express':
         optional: true
     dependencies:
-      '@nestjs/common': 8.4.7_whg6pvy6vwu66ypq7idiq2suxq
-      '@nestjs/core': 8.4.7_4vqalbqpgkpmtxhfqdv2kx42sq
-      tslib: 2.4.0
+      '@nestjs/common': 9.3.9_whg6pvy6vwu66ypq7idiq2suxq
+      '@nestjs/core': 9.3.9_6eenlv3uxu77azgl2iuo24dzau
+      tslib: 2.5.0
     dev: true
 
   /@nodelib/fs.scandir/2.1.5:
@@ -1054,6 +1096,13 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
+  /abort-controller/3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+    dependencies:
+      event-target-shim: 5.0.1
+    dev: true
+
   /abstract-logging/2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
     dev: true
@@ -1070,6 +1119,15 @@ packages:
     resolution: {integrity: sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+    dev: true
+
+  /ajv-formats/2.1.1:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.11.2
     dev: true
 
   /ajv/6.12.6:
@@ -1148,33 +1206,19 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /asynckit/0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: true
-
   /atomic-sleep/1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
     dev: true
 
-  /avvio/7.2.5:
-    resolution: {integrity: sha512-AOhBxyLVdpOad3TujtC9kL/9r3HnTkxwQ5ggOsYrvvZP1cCFvzHWJd5XxZDFuTn+IN8vkKSG5SEJrd27vCSbeA==}
+  /avvio/8.2.1:
+    resolution: {integrity: sha512-TAlMYvOuwGyLK3PfBb5WKBXZmXz2fVCgv23d6zZFdle/q3gPjmxBaeuC0pY0Dzs5PWMSgfqqEZkrye19GlDTgw==}
     dependencies:
       archy: 1.0.0
       debug: 4.3.4
       fastq: 1.14.0
-      queue-microtask: 1.2.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /axios/0.27.2:
-    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
-    dependencies:
-      follow-redirects: 1.15.2
-      form-data: 4.0.0
-    transitivePeerDependencies:
-      - debug
     dev: true
 
   /babel-jest/28.1.3_@babel+core@7.20.5:
@@ -1253,6 +1297,10 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
 
+  /base64-js/1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: true
+
   /brace-expansion/1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
     dependencies:
@@ -1293,6 +1341,13 @@ packages:
 
   /buffer-from/1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    dev: true
+
+  /buffer/6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
     dev: true
 
   /callsites/3.1.0:
@@ -1384,13 +1439,6 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
 
-  /combined-stream/1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-    dependencies:
-      delayed-stream: 1.0.0
-    dev: true
-
   /concat-map/0.0.1:
     resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
     dev: true
@@ -1440,11 +1488,6 @@ packages:
   /deepmerge/4.2.2:
     resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
     engines: {node: '>=0.10.0'}
-    dev: true
-
-  /delayed-stream/1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
     dev: true
 
   /detect-newline/3.1.0:
@@ -1658,6 +1701,16 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /event-target-shim/5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /events/3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+    dev: true
+
   /execa/5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -1689,6 +1742,10 @@ packages:
       jest-util: 28.1.3
     dev: true
 
+  /fast-content-type-parse/1.0.0:
+    resolution: {integrity: sha512-Xbc4XcysUXcsP5aHUU7Nq3OwvHq97C+WnbkeIefpeYLX+ryzFJlU6OStFJhs6Ol0LkUGpcK+wL0JwfM+FCU5IA==}
+    dev: true
+
   /fast-decode-uri-component/1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
     dev: true
@@ -1712,18 +1769,25 @@ packages:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
     dev: true
 
-  /fast-json-stringify/2.7.13:
-    resolution: {integrity: sha512-ar+hQ4+OIurUGjSJD1anvYSDcUflywhKjfxnsW4TBTD7+u0tJufv6DKRWoQk3vI6YBOWMoz0TQtfbe7dxbQmvA==}
-    engines: {node: '>= 10.0.0'}
+  /fast-json-stringify/5.6.2:
+    resolution: {integrity: sha512-F6xkRrXvtGbAiDSEI5Rk7qk2P63Y9kc8bO6Dnsd3Rt6sBNr2QxNFWs0JbKftgiyOfGxnJaRoHe4SizCTqeAyrA==}
     dependencies:
-      ajv: 6.12.6
-      deepmerge: 4.2.2
+      '@fastify/deepmerge': 1.3.0
+      ajv: 8.11.2
+      ajv-formats: 2.1.1
+      fast-deep-equal: 3.1.3
+      fast-uri: 2.2.0
       rfdc: 1.3.0
-      string-similarity: 4.0.4
     dev: true
 
   /fast-levenshtein/2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+    dev: true
+
+  /fast-querystring/1.1.1:
+    resolution: {integrity: sha512-qR2r+e3HvhEFmpdHMv//U8FnFlnYjaC6QKDuaXALDkw2kvHO8WDjxH+f/rHGR4Me4pnk8p9JAkRNTjYHAKRn2Q==}
+    dependencies:
+      fast-decode-uri-component: 1.0.1
     dev: true
 
   /fast-redact/3.1.2:
@@ -1735,55 +1799,32 @@ packages:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
     dev: true
 
-  /fastify-cors/6.0.3:
-    resolution: {integrity: sha512-fMbXubKKyBHHCfSBtsCi3+7VyVRdhJQmGes5gM+eGKkRErCdm0NaYO0ozd31BQBL1ycoTIjbqOZhJo4RTF/Vlg==}
-    dependencies:
-      fastify-plugin: 3.0.1
-      vary: 1.1.2
+  /fast-uri/2.2.0:
+    resolution: {integrity: sha512-cIusKBIt/R/oI6z/1nyfe2FvGKVTohVRfvkOhvx0nCEW+xf5NoCXjAHcWp93uOUBchzYcsvPlrapAdX1uW+YGg==}
     dev: true
 
-  /fastify-cors/6.1.0:
-    resolution: {integrity: sha512-QBKz32IoY/iuT74CunRY1XOSpjSTIOh9E3FxulXIBhd0D2vdgG0kDvy0eG6HA/88sRfWHeba43LkGEXPz0Rh8g==}
-    dependencies:
-      fastify-cors-deprecated: /fastify-cors/6.0.3
-      process-warning: 1.0.0
+  /fastify-plugin/4.5.0:
+    resolution: {integrity: sha512-79ak0JxddO0utAXAQ5ccKhvs6vX2MGyHHMMsmZkBANrq3hXc1CHzvNPHOcvTsVMEPl5I+NT+RO4YKMGehOfSIg==}
     dev: true
 
-  /fastify-formbody/5.2.0:
-    resolution: {integrity: sha512-d8Y5hCL82akPyoFiXh2wYOm3es0pV9jqoPo3pO9OV2cNF0cQx39J5WAVXzCh4MSt9Z2qF4Fy5gHlvlyESwjtvg==}
+  /fastify/4.13.0:
+    resolution: {integrity: sha512-p9ibdFWH3pZ7KPgmfHPKGUy2W4EWU2TEpwlcu58w4CwGyU3ARFfh2kwq6zpZ5W2ZGVbufi4tZbqHIHAlX/9Z/A==}
     dependencies:
-      fastify-plugin: 3.0.1
-    dev: true
-
-  /fastify-formbody/5.3.0:
-    resolution: {integrity: sha512-7cjFV2HE/doojyfTwCLToIFD6Hmbw2jVTbfqZ2lbUZznQWlSXu+MBQgqBU8T2nHcMfqSi9vx6PyX0LwTehuKkg==}
-    dependencies:
-      fastify-formbody-deprecated: /fastify-formbody/5.2.0
-      process-warning: 1.0.0
-    dev: true
-
-  /fastify-plugin/3.0.1:
-    resolution: {integrity: sha512-qKcDXmuZadJqdTm6vlCqioEbyewF60b/0LOFCcYN1B6BIZGlYJumWWOYs70SFYLDAH4YqdE1cxH/RKMG7rFxgA==}
-    dev: true
-
-  /fastify/3.29.0:
-    resolution: {integrity: sha512-zXSiDTdHJCHcmDrSje1f1RfzTmUTjMtHnPhh6cdokgfHhloQ+gy0Du+KlEjwTbcNC3Djj4GAsBzl6KvfI9Ah2g==}
-    dependencies:
-      '@fastify/ajv-compiler': 1.1.0
-      '@fastify/error': 2.0.0
+      '@fastify/ajv-compiler': 3.5.0
+      '@fastify/error': 3.2.0
+      '@fastify/fast-json-stringify-compiler': 4.2.0
       abstract-logging: 2.0.1
-      avvio: 7.2.5
-      fast-json-stringify: 2.7.13
-      find-my-way: 4.5.1
-      flatstr: 1.0.12
-      light-my-request: 4.12.0
-      pino: 6.14.0
-      process-warning: 1.0.0
+      avvio: 8.2.1
+      fast-content-type-parse: 1.0.0
+      find-my-way: 7.6.0
+      light-my-request: 5.8.0
+      pino: 8.11.0
+      process-warning: 2.1.0
       proxy-addr: 2.0.7
       rfdc: 1.3.0
       secure-json-parse: 2.6.0
       semver: 7.3.8
-      tiny-lru: 8.0.2
+      tiny-lru: 10.2.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1814,14 +1855,13 @@ packages:
       to-regex-range: 5.0.1
     dev: true
 
-  /find-my-way/4.5.1:
-    resolution: {integrity: sha512-kE0u7sGoUFbMXcOG/xpkmz4sRLCklERnBcg7Ftuu1iAxsfEt2S46RLJ3Sq7vshsEy2wJT2hZxE58XZK27qa8kg==}
-    engines: {node: '>=10'}
+  /find-my-way/7.6.0:
+    resolution: {integrity: sha512-H7berWdHJ+5CNVr4ilLWPai4ml7Y2qAsxjw3pfeBxPigZmaDTzF0wjJLj90xRCmGcWYcyt050yN+34OZDJm1eQ==}
+    engines: {node: '>=14'}
     dependencies:
-      fast-decode-uri-component: 1.0.1
       fast-deep-equal: 3.1.3
+      fast-querystring: 1.1.1
       safe-regex2: 2.0.0
-      semver-store: 0.3.0
     dev: true
 
   /find-up/4.1.0:
@@ -1848,31 +1888,8 @@ packages:
       rimraf: 3.0.2
     dev: true
 
-  /flatstr/1.0.12:
-    resolution: {integrity: sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==}
-    dev: true
-
   /flatted/3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
-    dev: true
-
-  /follow-redirects/1.15.2:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dev: true
-
-  /form-data/4.0.0:
-    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
-    engines: {node: '>= 6'}
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
     dev: true
 
   /forwarded/0.2.0:
@@ -2001,6 +2018,10 @@ packages:
   /human-signals/2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+    dev: true
+
+  /ieee754/1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
     dev: true
 
   /ignore/5.2.1:
@@ -2614,21 +2635,11 @@ packages:
       type-check: 0.4.0
     dev: true
 
-  /light-my-request/4.12.0:
-    resolution: {integrity: sha512-0y+9VIfJEsPVzK5ArSIJ8Dkxp8QMP7/aCuxCUtG/tr9a2NoOf/snATE/OUc05XUplJCEnRh6gTkH7xh9POt1DQ==}
+  /light-my-request/5.8.0:
+    resolution: {integrity: sha512-4BtD5C+VmyTpzlDPCZbsatZMJVgUIciSOwYhJDCbLffPZ35KoDkDj4zubLeHDEb35b4kkPeEv5imbh+RJxK/Pg==}
     dependencies:
-      ajv: 8.11.2
       cookie: 0.5.0
-      process-warning: 1.0.0
-      set-cookie-parser: 2.5.1
-    dev: true
-
-  /light-my-request/5.0.0:
-    resolution: {integrity: sha512-0OPHKV+uHgBOnRokzL1LqeMCnSAo5l/rZS7kyB6G1I8qxGCvhXpq1M6WK565Y9A5CSn50l3DVaHnJ5FCdpguZQ==}
-    dependencies:
-      ajv: 8.11.2
-      cookie: 0.5.0
-      process-warning: 1.0.0
+      process-warning: 2.1.0
       set-cookie-parser: 2.5.1
     dev: true
 
@@ -2699,27 +2710,6 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /middie/6.1.0:
-    resolution: {integrity: sha512-akpWXv9QFJ3mXq26kiej7nI4EiID1zEVLq5dxRbrkESMUNNOdTFJjt7Uk9mkcR7D9oR+6km3l3Oah9uQof+Uig==}
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      fastify-plugin: 3.0.1
-      path-to-regexp: 6.2.1
-      reusify: 1.0.4
-    dev: true
-
-  /mime-db/1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-    dev: true
-
-  /mime-types/2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-    dependencies:
-      mime-db: 1.52.0
-    dev: true
-
   /mimic-fn/2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -2729,6 +2719,12 @@ packages:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
+    dev: true
+
+  /mnemonist/0.39.5:
+    resolution: {integrity: sha512-FPUtkhtJ0efmEFGpU14x7jGbTB+s18LrzRL2KgoWz9YvcY3cPomz8tih01GbHwnGk/OmkOKfqd/RAQoc8Lm7DQ==}
+    dependencies:
+      obliterator: 2.0.4
     dev: true
 
   /ms/2.1.2:
@@ -2775,9 +2771,12 @@ packages:
       path-key: 3.1.1
     dev: true
 
-  /object-hash/3.0.0:
-    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
-    engines: {node: '>= 6'}
+  /obliterator/2.0.4:
+    resolution: {integrity: sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ==}
+    dev: true
+
+  /on-exit-leak-free/2.1.0:
+    resolution: {integrity: sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w==}
     dev: true
 
   /once/1.4.0:
@@ -2896,21 +2895,32 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
-  /pino-std-serializers/3.2.0:
-    resolution: {integrity: sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==}
+  /pino-abstract-transport/1.0.0:
+    resolution: {integrity: sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==}
+    dependencies:
+      readable-stream: 4.3.0
+      split2: 4.1.0
     dev: true
 
-  /pino/6.14.0:
-    resolution: {integrity: sha512-iuhEDel3Z3hF9Jfe44DPXR8l07bhjuFY3GMHIXbjnY9XcafbyDDwl2sN2vw2GjMPf5Nkoe+OFao7ffn9SXaKDg==}
+  /pino-std-serializers/6.1.0:
+    resolution: {integrity: sha512-KO0m2f1HkrPe9S0ldjx7za9BJjeHqBku5Ch8JyxETxT8dEFGz1PwgrHaOQupVYitpzbFSYm7nnljxD8dik2c+g==}
+    dev: true
+
+  /pino/8.11.0:
+    resolution: {integrity: sha512-Z2eKSvlrl2rH8p5eveNUnTdd4AjJk8tAsLkHYZQKGHP4WTh2Gi1cOSOs3eWPqaj+niS3gj4UkoreoaWgF3ZWYg==}
     hasBin: true
     dependencies:
+      atomic-sleep: 1.0.0
       fast-redact: 3.1.2
-      fast-safe-stringify: 2.1.1
-      flatstr: 1.0.12
-      pino-std-serializers: 3.2.0
-      process-warning: 1.0.0
+      on-exit-leak-free: 2.1.0
+      pino-abstract-transport: 1.0.0
+      pino-std-serializers: 6.1.0
+      process-warning: 2.1.0
       quick-format-unescaped: 4.0.4
-      sonic-boom: 1.4.1
+      real-require: 0.2.0
+      safe-stable-stringify: 2.4.2
+      sonic-boom: 3.2.1
+      thread-stream: 2.3.0
     dev: true
 
   /pirates/4.0.5:
@@ -2946,8 +2956,13 @@ packages:
       react-is: 18.2.0
     dev: true
 
-  /process-warning/1.0.0:
-    resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
+  /process-warning/2.1.0:
+    resolution: {integrity: sha512-9C20RLxrZU/rFnxWncDkuF6O999NdIf3E1ws4B0ZeY3sRVPzWBMsYDE2lxjxhiXxg464cQTgKUGm8/i6y2YGXg==}
+    dev: true
+
+  /process/0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
     dev: true
 
   /prompts/2.4.2:
@@ -2985,6 +3000,21 @@ packages:
 
   /react-is/18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+    dev: true
+
+  /readable-stream/4.3.0:
+    resolution: {integrity: sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+    dev: true
+
+  /real-require/0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
     dev: true
 
   /reflect-metadata/0.1.13:
@@ -3076,12 +3106,13 @@ packages:
       ret: 0.2.2
     dev: true
 
-  /secure-json-parse/2.6.0:
-    resolution: {integrity: sha512-B9osKohb6L+EZ6Kve3wHKfsAClzOC/iISA2vSuCe5Jx5NAKiwitfxx8ZKYapHXr0sYRj7UZInT7pLb3rp2Yx6A==}
+  /safe-stable-stringify/2.4.2:
+    resolution: {integrity: sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==}
+    engines: {node: '>=10'}
     dev: true
 
-  /semver-store/0.3.0:
-    resolution: {integrity: sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg==}
+  /secure-json-parse/2.6.0:
+    resolution: {integrity: sha512-B9osKohb6L+EZ6Kve3wHKfsAClzOC/iISA2vSuCe5Jx5NAKiwitfxx8ZKYapHXr0sYRj7UZInT7pLb3rp2Yx6A==}
     dev: true
 
   /semver/6.3.0:
@@ -3126,11 +3157,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /sonic-boom/1.4.1:
-    resolution: {integrity: sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==}
+  /sonic-boom/3.2.1:
+    resolution: {integrity: sha512-iITeTHxy3B9FGu8aVdiDXUVAcHMF9Ss0cCsAOo2HfCrmVGT3/DT5oYaeu0M/YKZDlKTvChEyPq0zI9Hf33EX6A==}
     dependencies:
       atomic-sleep: 1.0.0
-      flatstr: 1.0.12
     dev: true
 
   /source-map-support/0.5.13:
@@ -3143,6 +3173,11 @@ packages:
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /split2/4.1.0:
+    resolution: {integrity: sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==}
+    engines: {node: '>= 10.x'}
     dev: true
 
   /sprintf-js/1.0.3:
@@ -3162,10 +3197,6 @@ packages:
     dependencies:
       char-regex: 1.0.2
       strip-ansi: 6.0.1
-    dev: true
-
-  /string-similarity/4.0.4:
-    resolution: {integrity: sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==}
     dev: true
 
   /string-width/4.2.3:
@@ -3254,9 +3285,15 @@ packages:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
 
-  /tiny-lru/8.0.2:
-    resolution: {integrity: sha512-ApGvZ6vVvTNdsmt676grvCkUCGwzG9IqXma5Z07xJgiC5L7akUMof5U8G2JTI9Rz/ovtVhJBlY6mNhEvtjzOIg==}
-    engines: {node: '>=6'}
+  /thread-stream/2.3.0:
+    resolution: {integrity: sha512-kaDqm1DET9pp3NXwR8382WHbnpXnRkN9xGN9dQt3B2+dmXiW8X1SOwmFOxAErEQ47ObhZ96J6yhZNXuyCOL7KA==}
+    dependencies:
+      real-require: 0.2.0
+    dev: true
+
+  /tiny-lru/10.2.1:
+    resolution: {integrity: sha512-cxcNyX4O50FDnB5x9jdEJupYC+9PPutt6wT16TaOtXeHfV9t41aFqg0VniB9YK5KmBeqmZaYriNMajm/5TtA7Q==}
+    engines: {node: '>=12'}
     dev: true
 
   /tmpl/1.0.5:
@@ -3320,12 +3357,12 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tslib/2.4.0:
-    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
-    dev: true
-
   /tslib/2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
+    dev: true
+
+  /tslib/2.5.0:
+    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
     dev: true
 
   /tsutils/3.21.0_typescript@4.7.4:
@@ -3366,6 +3403,13 @@ packages:
     hasBin: true
     dev: true
 
+  /uid/2.0.1:
+    resolution: {integrity: sha512-PF+1AnZgycpAIEmNtjxGBVmKbZAQguaa4pBUq6KNaGEcpzZ2klCNZLM34tsjp76maN00TttiiUf6zkIBpJQm2A==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@lukeed/csprng': 1.0.1
+    dev: true
+
   /update-browserslist-db/1.0.10_browserslist@4.21.4:
     resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==}
     hasBin: true
@@ -3383,11 +3427,6 @@ packages:
       punycode: 2.1.1
     dev: true
 
-  /uuid/8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    hasBin: true
-    dev: true
-
   /v8-compile-cache/2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
     dev: true
@@ -3399,11 +3438,6 @@ packages:
       '@jridgewell/trace-mapping': 0.3.17
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.9.0
-    dev: true
-
-  /vary/1.1.2:
-    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
-    engines: {node: '>= 0.8'}
     dev: true
 
   /walker/1.0.8:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,16 +7,21 @@ specifiers:
   '@nestjs/testing': ^8.4.7
   '@types/jest': ^28.1.8
   '@types/node': ^16.18.6
+  '@types/ramda': ^0.28.23
   '@typescript-eslint/eslint-plugin': ~5.42.1
   '@typescript-eslint/parser': ~5.42.1
   eslint: 8.22.0
   eslint-plugin-unused-imports: ^2.0.0
   jest: ^28.1.3
   prettier: ^2.8.1
+  ramda: ^0.28.0
   reflect-metadata: ^0.1.13
   rxjs: ^7.6.0
   ts-jest: ^28.0.8
   typescript: ~4.7.4
+
+dependencies:
+  ramda: 0.28.0
 
 devDependencies:
   '@nestjs/common': 8.4.7_whg6pvy6vwu66ypq7idiq2suxq
@@ -25,6 +30,7 @@ devDependencies:
   '@nestjs/testing': 8.4.7_7tsmhnugyerf5okgqzer2mfqme
   '@types/jest': 28.1.8
   '@types/node': 16.18.6
+  '@types/ramda': 0.28.23
   '@typescript-eslint/eslint-plugin': 5.42.1_annzddb5ldaj4lw3vaqmzpjebi
   '@typescript-eslint/parser': 5.42.1_4rv7y5c6xz3vfxwhbrcxxi73bq
   eslint: 8.22.0
@@ -893,6 +899,12 @@ packages:
 
   /@types/prettier/2.7.1:
     resolution: {integrity: sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==}
+    dev: true
+
+  /@types/ramda/0.28.23:
+    resolution: {integrity: sha512-9TYWiwkew+mCMsL7jZ+kkzy6QXn8PL5/SKmBPmjgUlTpkokZWTBr+OhiIUDztpAEbslWyt24NNfEmZUBFmnXig==}
+    dependencies:
+      ts-toolbelt: 6.15.5
     dev: true
 
   /@types/semver/7.3.13:
@@ -2967,6 +2979,10 @@ packages:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
     dev: true
 
+  /ramda/0.28.0:
+    resolution: {integrity: sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==}
+    dev: false
+
   /react-is/18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
@@ -3294,6 +3310,10 @@ packages:
       semver: 7.3.8
       typescript: 4.7.4
       yargs-parser: 21.1.1
+    dev: true
+
+  /ts-toolbelt/6.15.5:
+    resolution: {integrity: sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==}
     dev: true
 
   /tslib/1.14.1:

--- a/src/__test__/aop.module.test.ts
+++ b/src/__test__/aop.module.test.ts
@@ -25,7 +25,17 @@ describe('AopModule', () => {
     const app = module.createNestApplication(new FastifyAdapter());
     await app.init();
     const fooService = app.get(FooService);
-    expect(Object.getPrototypeOf(fooService.foo)).toBe(fooService.originalFoo);
+
+    expect(Object.keys(fooService.foo)).toMatchInlineSnapshot(`Array []`);
+    expect((fooService.foo as any)['original']).toBe(true);
+
+    const proto = Object.getPrototypeOf(fooService.foo);
+    expect(Object.keys(proto)).toMatchInlineSnapshot(`
+    Array [
+      "original",
+    ]
+    `);
+    expect((proto as any)['original']).toBe(true);
   });
 
   it('Decorator order must be guaranteed', async () => {
@@ -36,9 +46,8 @@ describe('AopModule', () => {
     const app = module.createNestApplication(new FastifyAdapter());
     await app.init();
     const fooService = app.get(FooService);
-    // TODO: https://github.com/toss/nestjs-aop/issues/7
     expect(fooService.multipleDecorated('original', 0)).toMatchInlineSnapshot(
-      `"original0:ts_decroator_4:ts_decroator_2:dependency_5:dependency_3:dependency_1"`,
+      `"original0:dependency_5:ts_decroator_4:dependency_3:ts_decroator_2:dependency_1"`,
     );
   });
 });

--- a/src/__test__/aop.module.test.ts
+++ b/src/__test__/aop.module.test.ts
@@ -26,9 +26,12 @@ describe('AopModule', () => {
     await app.init();
     const fooService = app.get(FooService);
 
+    // In the 'SetOriginalTrue' decorator, the original field in the originalFn was set to true.
+    // Verify that the 'fooService.foo' object has no properties and its 'original' property is true
     expect(Object.keys(fooService.foo)).toMatchInlineSnapshot(`Array []`);
     expect((fooService.foo as any)['original']).toBe(true);
 
+    // Get the prototype of the 'fooService.foo' object and verify that it only has an 'original' property
     const proto = Object.getPrototypeOf(fooService.foo);
     expect(Object.keys(proto)).toMatchInlineSnapshot(`
     Array [

--- a/src/__test__/fixture/foo/foo.decorator.ts
+++ b/src/__test__/fixture/foo/foo.decorator.ts
@@ -34,3 +34,9 @@ export const NotAopFoo = (options: FooOptions): MethodDecorator => {
     Object.setPrototypeOf(descriptor.value, originMethod);
   };
 };
+
+export const SetOriginalTrue = () => {
+  return (_: any, __: string | symbol, descriptor: PropertyDescriptor) => {
+    descriptor.value['original'] = true;
+  };
+};

--- a/src/__test__/fixture/foo/foo.decorator.ts
+++ b/src/__test__/fixture/foo/foo.decorator.ts
@@ -9,7 +9,7 @@ export const FOO = Symbol('FOO');
 type FooOptions = {
   options: string;
 };
-export const Foo = createDecorator<FooOptions>(FOO);
+export const Foo = (options: FooOptions) => createDecorator(FOO, options);
 
 @Aspect(FOO)
 export class FooDecorator implements LazyDecorator<FooService['foo'], FooOptions> {

--- a/src/__test__/fixture/foo/foo.service.ts
+++ b/src/__test__/fixture/foo/foo.service.ts
@@ -1,14 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { Foo, NotAopFoo } from './foo.decorator';
+import { Foo, NotAopFoo, SetOriginalTrue } from './foo.decorator';
 
 @Injectable()
 export class FooService {
-  originalFoo: unknown;
-  constructor() {
-    this.originalFoo = this.foo;
-  }
-
   @Foo({ options: 'options' })
+  @SetOriginalTrue()
   foo(arg1: string, arg2: number) {
     return arg1 + arg2;
   }

--- a/src/aspect.ts
+++ b/src/aspect.ts
@@ -3,8 +3,8 @@ import { applyDecorators, Injectable, SetMetadata } from '@nestjs/common';
 export const ASPECT = Symbol('ASPECT');
 
 /**
- * AOP 를 사용하기 위한 데코레이터 입니다.
- * @see LazyDecorator 도 구현이 필요합니다.
+ * Decorator to apply to providers that implements LazyDecorator.
+ * @see LazyDecorator
  */
 export function Aspect(metadataKey: string | symbol) {
   return applyDecorators(SetMetadata(ASPECT, metadataKey), Injectable);

--- a/src/auto-aspect-executor.ts
+++ b/src/auto-aspect-executor.ts
@@ -35,7 +35,7 @@ export class AutoAspectExecutor implements OnModuleInit {
             lazyDecorators.forEach((lazyDecorator) => {
               const metadataKey = this.reflector.get(ASPECT, lazyDecorator.constructor);
 
-              const metadataList: { metadata: unknown; aopSymbol: symbol }[] = this.reflector.get(
+              const metadataList: { metadata?: unknown; aopSymbol: symbol }[] = this.reflector.get(
                 metadataKey,
                 instance[methodName],
               );

--- a/src/auto-aspect-executor.ts
+++ b/src/auto-aspect-executor.ts
@@ -35,7 +35,7 @@ export class AutoAspectExecutor implements OnModuleInit {
             lazyDecorators.forEach((lazyDecorator) => {
               const metadataKey = this.reflector.get(ASPECT, lazyDecorator.constructor);
 
-              const metadataList: { options: unknown; aopSymbol: symbol }[] = this.reflector.get(
+              const metadataList: { metadata: unknown; aopSymbol: symbol }[] = this.reflector.get(
                 metadataKey,
                 instance[methodName],
               );
@@ -43,13 +43,13 @@ export class AutoAspectExecutor implements OnModuleInit {
                 return;
               }
 
-              for (const { options, aopSymbol } of metadataList) {
+              for (const { metadata, aopSymbol } of metadataList) {
                 instance[methodName][aopSymbol] = once((originalFn: any) => {
                   const wrappedMethod = lazyDecorator.wrap({
                     instance,
                     methodName,
                     method: originalFn.bind(instance),
-                    metadata: options,
+                    metadata,
                   });
                   Object.setPrototypeOf(wrappedMethod, instance[methodName]);
                   return wrappedMethod;

--- a/src/create-decorator.ts
+++ b/src/create-decorator.ts
@@ -11,8 +11,8 @@ export function createDecorator<T = void>(
 ): MethodDecorator {
   const aopSymbol = Symbol('AOP_DECORATOR');
   return applyDecorators(
-    AddMetadata<symbol | string, { options: T; aopSymbol: symbol }>(metadataKey, {
-      options: metadata,
+    AddMetadata<symbol | string, { metadata: T; aopSymbol: symbol }>(metadataKey, {
+      metadata,
       aopSymbol,
     }),
     function (target: any, propertyKey: string | symbol, descriptor: PropertyDescriptor) {

--- a/src/create-decorator.ts
+++ b/src/create-decorator.ts
@@ -1,24 +1,22 @@
 import { applyDecorators } from '@nestjs/common';
 import { AddMetadata } from './utils';
 
-export function createDecorator<T = void>(metadataKey: any) {
-  return (options: T): MethodDecorator => {
-    const aopSymbol = Symbol('AOP_DECORATOR');
-    return applyDecorators(
-      AddMetadata<{ options: T; aopSymbol: symbol }>(metadataKey, { options, aopSymbol }),
-      function (target: any, propertyKey: string | symbol, descriptor: PropertyDescriptor) {
-        const originalFn = descriptor.value;
-        descriptor.value = (...args: any[]) => {
-          if (target[propertyKey][aopSymbol]) {
-            // If there is a wrapper stored in the method, use it
-            return target[propertyKey][aopSymbol](originalFn).apply(target, args);
-          }
-          // if there is no wrapper that comes out of method, call originalFn
-          return originalFn.apply(target, args);
-        };
+export function createDecorator<T = void>(metadataKey: any, metadata: T): MethodDecorator {
+  const aopSymbol = Symbol('AOP_DECORATOR');
+  return applyDecorators(
+    AddMetadata<{ options: T; aopSymbol: symbol }>(metadataKey, { options: metadata, aopSymbol }),
+    function (target: any, propertyKey: string | symbol, descriptor: PropertyDescriptor) {
+      const originalFn = descriptor.value;
+      descriptor.value = (...args: any[]) => {
+        if (target[propertyKey][aopSymbol]) {
+          // If there is a wrapper stored in the method, use it
+          return target[propertyKey][aopSymbol](originalFn).apply(target, args);
+        }
+        // if there is no wrapper that comes out of method, call originalFn
+        return originalFn.apply(target, args);
+      };
 
-        Object.setPrototypeOf(descriptor.value, originalFn);
-      },
-    );
-  };
+      Object.setPrototypeOf(descriptor.value, originalFn);
+    },
+  );
 }

--- a/src/create-decorator.ts
+++ b/src/create-decorator.ts
@@ -1,5 +1,24 @@
+import { applyDecorators } from '@nestjs/common';
 import { AddMetadata } from './utils';
 
 export function createDecorator<T = void>(metadataKey: any) {
-  return (options: T) => AddMetadata(metadataKey, options);
+  return (options: T): MethodDecorator => {
+    const aopSymbol = Symbol('AOP_DECORATOR');
+    return applyDecorators(
+      AddMetadata<{ options: T; aopSymbol: symbol }>(metadataKey, { options, aopSymbol }),
+      function (target: any, propertyKey: string | symbol, descriptor: PropertyDescriptor) {
+        const originalFn = descriptor.value;
+        descriptor.value = (...args: any[]) => {
+          if (target[propertyKey][aopSymbol]) {
+            // If there is a wrapper stored in the method, use it
+            return target[propertyKey][aopSymbol](originalFn).apply(target, args);
+          }
+          // if there is no wrapper that comes out of method, call originalFn
+          return originalFn.apply(target, args);
+        };
+
+        Object.setPrototypeOf(descriptor.value, originalFn);
+      },
+    );
+  };
 }

--- a/src/create-decorator.ts
+++ b/src/create-decorator.ts
@@ -1,10 +1,20 @@
 import { applyDecorators } from '@nestjs/common';
 import { AddMetadata } from './utils';
 
-export function createDecorator<T = void>(metadataKey: any, metadata: T): MethodDecorator {
+/**
+ * @param metadataKey equal to 1st argument of Aspect Decorator
+ * @param metadata The value corresponding to the metadata of WrapParams. It can be obtained from LazyDecorator's warp method and used.
+ */
+export function createDecorator<T = void>(
+  metadataKey: symbol | string,
+  metadata: T,
+): MethodDecorator {
   const aopSymbol = Symbol('AOP_DECORATOR');
   return applyDecorators(
-    AddMetadata<{ options: T; aopSymbol: symbol }>(metadataKey, { options: metadata, aopSymbol }),
+    AddMetadata<symbol | string, { options: T; aopSymbol: symbol }>(metadataKey, {
+      options: metadata,
+      aopSymbol,
+    }),
     function (target: any, propertyKey: string | symbol, descriptor: PropertyDescriptor) {
       const originalFn = descriptor.value;
       descriptor.value = (...args: any[]) => {

--- a/src/create-decorator.ts
+++ b/src/create-decorator.ts
@@ -5,13 +5,13 @@ import { AddMetadata } from './utils';
  * @param metadataKey equal to 1st argument of Aspect Decorator
  * @param metadata The value corresponding to the metadata of WrapParams. It can be obtained from LazyDecorator's warp method and used.
  */
-export function createDecorator<T = void>(
+export const createDecorator = (
   metadataKey: symbol | string,
-  metadata: T,
-): MethodDecorator {
+  metadata?: unknown,
+): MethodDecorator => {
   const aopSymbol = Symbol('AOP_DECORATOR');
   return applyDecorators(
-    AddMetadata<symbol | string, { metadata: T; aopSymbol: symbol }>(metadataKey, {
+    AddMetadata<symbol | string, { metadata?: unknown; aopSymbol: symbol }>(metadataKey, {
       metadata,
       aopSymbol,
     }),
@@ -29,4 +29,4 @@ export function createDecorator<T = void>(
       Object.setPrototypeOf(descriptor.value, originalFn);
     },
   );
-}
+};

--- a/src/utils/add-metadata.ts
+++ b/src/utils/add-metadata.ts
@@ -1,4 +1,4 @@
-export const AddMetadata = <K = string, V = any>(
+export const AddMetadata = <K extends string | symbol = string, V = any>(
   metadataKey: K,
   metadataValue: V,
 ): MethodDecorator => {


### PR DESCRIPTION
## Overview
I solved this issue by decorating it first and then injecting Lazy fn.
Decorate the method in the `createDecorator` first, and if there is a wrapper injected later, wrap it and use it.

Nestjs 9 is now available.