### PR TITLE
fix: Instead of lazy wrap method, the originalFn is handed over to AddMetadata and wrapped immediately.

### DIFF
--- a/src/__test__/aop.module.test.ts
+++ b/src/__test__/aop.module.test.ts
@@ -34,10 +34,10 @@ describe('AopModule', () => {
     // Get the prototype of the 'fooService.foo' object and verify that it only has an 'original' property
     const proto = Object.getPrototypeOf(fooService.foo);
     expect(Object.keys(proto)).toMatchInlineSnapshot(`
-    Array [
-      "original",
-    ]
-    `);
+          Array [
+            "original",
+          ]
+        `);
     expect((proto as any)['original']).toBe(true);
   });
 
@@ -50,7 +50,7 @@ describe('AopModule', () => {
     await app.init();
     const fooService = app.get(FooService);
     expect(fooService.multipleDecorated('original', 0)).toMatchInlineSnapshot(
-      `"original0:dependency_5:ts_decroator_4:dependency_3:ts_decroator_2:dependency_1"`,
+      `"original0:dependency_7:dependency_6:ts_decroator_5:ts_decroator_4:dependency_3:ts_decroator_2:dependency_1:dependency_0"`,
     );
   });
 });

--- a/src/__test__/fixture/foo/foo.service.ts
+++ b/src/__test__/fixture/foo/foo.service.ts
@@ -9,11 +9,14 @@ export class FooService {
     return arg1 + arg2;
   }
 
+  @Foo({ options: '0' })
   @Foo({ options: '1' })
   @NotAopFoo({ options: '2' })
   @Foo({ options: '3' })
   @NotAopFoo({ options: '4' })
-  @Foo({ options: '5' })
+  @NotAopFoo({ options: '5' })
+  @Foo({ options: '6' })
+  @Foo({ options: '7' })
   multipleDecorated(arg1: string, arg2: number) {
     return arg1 + arg2;
   }

--- a/src/create-decorator.ts
+++ b/src/create-decorator.ts
@@ -1,3 +1,4 @@
+import { applyDecorators } from '@nestjs/common';
 import { AddMetadata } from './utils';
 
 /**
@@ -9,28 +10,32 @@ export const createDecorator = (
   metadata?: unknown,
 ): MethodDecorator => {
   const aopSymbol = Symbol('AOP_DECORATOR');
-  return function (target: any, propertyKey: string | symbol, descriptor: PropertyDescriptor) {
-    const originalFn = descriptor.value;
+  return applyDecorators(
+    // 1. Add metadata to the method
+    (target: any, propertyKey: string | symbol, descriptor: PropertyDescriptor) => {
+      return AddMetadata<
+        symbol | string,
+        { metadata?: unknown; aopSymbol: symbol; originalFn: unknown }
+      >(metadataKey, {
+        originalFn: descriptor.value,
+        metadata,
+        aopSymbol,
+      })(target, propertyKey, descriptor);
+    },
+    // 2. Wrap the method before the lazy decorator is executed
+    function (target: any, propertyKey: string | symbol, descriptor: PropertyDescriptor) {
+      const originalFn = descriptor.value;
 
-    descriptor.value = (...args: any[]) => {
-      if (target[propertyKey][aopSymbol]) {
-        // If there is a wrapper stored in the method, use it
-        return target[propertyKey][aopSymbol].apply(target, args);
-      }
-      // if there is no wrapper that comes out of method, call originalFn
-      return originalFn.apply(target, args);
-    };
+      descriptor.value = (...args: any[]) => {
+        if (target[propertyKey][aopSymbol]) {
+          // If there is a wrapper stored in the method, use it
+          return target[propertyKey][aopSymbol].apply(target, args);
+        }
+        // if there is no wrapper that comes out of method, call originalFn
+        return originalFn.apply(target, args);
+      };
 
-    Object.setPrototypeOf(descriptor.value, originalFn);
-
-    const addMetadataDecorator = AddMetadata<
-      symbol | string,
-      { metadata?: unknown; aopSymbol: symbol; originalFn: unknown }
-    >(metadataKey, {
-      originalFn,
-      metadata,
-      aopSymbol,
-    });
-    return addMetadataDecorator(target, propertyKey, descriptor);
-  };
+      Object.setPrototypeOf(descriptor.value, originalFn);
+    },
+  );
 };


### PR DESCRIPTION
## Overview
When lazy wrap is performed, the wrap is executed when the call is made rather than in the onModuleInit step. I modified the warp to be invoked in the onModuleInit step.
