### PR TITLE
fix: #18 Each instance should have its dependencies applied correctly

### DIFF
--- a/src/__test__/aop.module.test.ts
+++ b/src/__test__/aop.module.test.ts
@@ -5,6 +5,7 @@ import { Test } from '@nestjs/testing';
 import { AopModule } from '../aop.module';
 import { BarModule, BarService, barThisValue } from './fixture/bar';
 import { FooModule, FooService, fooThisValue } from './fixture/foo';
+import { DuplicateService } from './fixture/foo/duplicate.service';
 import { FooController } from './fixture/foo/foo.controller';
 
 describe('AopModule', () => {
@@ -104,5 +105,20 @@ describe('AopModule', () => {
       barService.thisTest();
       expect(barThisValue).toBe(barService);
     });
+  });
+
+  it('Each instance should have its dependencies applied correctly', async () => {
+    const module = await Test.createTestingModule({
+      imports: [AopModule, FooModule],
+    }).compile();
+
+    const app = module.createNestApplication(new FastifyAdapter());
+    await app.init();
+
+    const duplicateService1: DuplicateService = app.get('DUPLICATE_1');
+    const duplicateService2: DuplicateService = app.get('DUPLICATE_2');
+
+    expect(duplicateService1.getValue()).toMatchInlineSnapshot(`"1:dependency_value"`);
+    expect(duplicateService2.getValue()).toMatchInlineSnapshot(`"2:dependency_value"`);
   });
 });

--- a/src/__test__/fixture/foo/duplicate.service.ts
+++ b/src/__test__/fixture/foo/duplicate.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { Foo } from '../foo';
+
+@Injectable()
+export class DuplicateService {
+  constructor(private readonly value: number) {}
+
+  @Foo({ options: 'value' })
+  getValue() {
+    return this.value;
+  }
+}

--- a/src/__test__/fixture/foo/foo.module.ts
+++ b/src/__test__/fixture/foo/foo.module.ts
@@ -3,12 +3,24 @@ import { SampleModule } from '../sample';
 import { FooController } from './foo.controller';
 import { FooDecorator } from './foo.decorator';
 
+import { DuplicateService } from './duplicate.service';
 import { FooService } from './foo.service';
 
 @Module({
   imports: [SampleModule],
   controllers: [FooController],
-  providers: [FooService, FooDecorator],
-  exports: [FooService],
+  providers: [
+    FooService,
+    {
+      provide: 'DUPLICATE_1',
+      useValue: new DuplicateService(1),
+    },
+    {
+      provide: 'DUPLICATE_2',
+      useValue: new DuplicateService(2),
+    },
+    FooDecorator,
+  ],
+  exports: [FooService, 'DUPLICATE_1', 'DUPLICATE_2'],
 })
 export class FooModule {}

--- a/src/auto-aspect-executor.ts
+++ b/src/auto-aspect-executor.ts
@@ -67,8 +67,11 @@ export class AutoAspectExecutor implements OnModuleInit {
               method: originalFn.bind(instance),
               metadata,
             });
+
             Object.setPrototypeOf(wrappedMethod, instance[methodName]);
-            instance[methodName][aopSymbol] = wrappedMethod;
+
+            instance[aopSymbol] ??= {};
+            instance[aopSymbol][methodName] = wrappedMethod;
           }
         });
       }

--- a/src/create-decorator.ts
+++ b/src/create-decorator.ts
@@ -27,9 +27,9 @@ export const createDecorator = (
       const originalFn = descriptor.value;
 
       descriptor.value = function (this: any, ...args: any[]) {
-        if (this[propertyKey][aopSymbol]) {
+        if (this[aopSymbol]?.[propertyKey]) {
           // If there is a wrapper stored in the method, use it
-          return this[propertyKey][aopSymbol].apply(this, args);
+          return this[aopSymbol][propertyKey].apply(this, args);
         }
         // if there is no wrapper that comes out of method, call originalFn
         return originalFn.apply(this, args);


### PR DESCRIPTION
close #18 

When attaching a value to instance[methodName][aopSymbol], the value is attached to the method in the prototype. To correctly have each instance own its own method, the value should be attached to instance[aopSymbol][methodName].

