### PR TITLE
feat: request scoped provider aop support

### DIFF
--- a/src/__test__/aop.module.test.ts
+++ b/src/__test__/aop.module.test.ts
@@ -12,32 +12,40 @@ import {
   FooService,
   fooThisValue,
 } from './fixture/foo';
+import { BazModule, BazService, bazThisValue } from './fixture/baz';
 
 describe('AopModule', () => {
-  it('Lazy decoder overwrites the original function', async () => {
+  it('Lazy decorator overwrites the original function', async () => {
     const module = await Test.createTestingModule({
-      imports: [AopModule, FooModule],
+      imports: [AopModule, FooModule, BazModule],
     }).compile();
 
     const app = module.createNestApplication(new FastifyAdapter());
     await app.init();
-    const fooService = app.get(FooService);
+    const fooService = app.get(FooService),
+      bazService = await app.resolve(BazService);
     expect(fooService.foo('original', 0)).toMatchInlineSnapshot(`"original0:dependency_options"`);
+    expect(bazService.baz('original', 0)).toMatchInlineSnapshot(`"original0:dependency_options"`);
   });
 
   it('Prototype of the overwritten function must be the original function', async () => {
     const module = await Test.createTestingModule({
-      imports: [AopModule, FooModule],
+      imports: [AopModule, FooModule, BazModule],
     }).compile();
 
     const app = module.createNestApplication(new FastifyAdapter());
     await app.init();
-    const fooService = app.get(FooService);
+    const fooService = app.get(FooService),
+      bazService = await app.resolve(BazService);
 
     // In the 'SetOriginalTrue' decorator, the original field in the originalFn was set to true.
     // Verify that the 'fooService.foo' object has no properties and its 'original' property is true
     expect(Object.keys(fooService.foo)).toMatchInlineSnapshot(`Array []`);
     expect((fooService.foo as any)['original']).toBe(true);
+
+    // Verify that the 'bazService.baz' object has no properties and its 'original' property is true
+    expect(Object.keys(bazService.baz)).toMatchInlineSnapshot(`Array []`);
+    expect((bazService.baz as any)['original']).toBe(true);
 
     // Get the prototype of the 'fooService.foo' object and verify that it only has an 'original' property
     const proto = Object.getPrototypeOf(fooService.foo);
@@ -47,11 +55,20 @@ describe('AopModule', () => {
           ]
         `);
     expect((proto as any)['original']).toBe(true);
+
+    // Get the prototype of the 'bazService.baz' object and verify that it only has an 'original' property
+    const proto2 = Object.getPrototypeOf(bazService.baz);
+    expect(Object.keys(proto2)).toMatchInlineSnapshot(`
+          Array [
+            "original",
+          ]
+        `);
+    expect((proto2 as any)['original']).toBe(true);
   });
 
   it('Decorator order must be guaranteed', async () => {
     const module = await Test.createTestingModule({
-      imports: [AopModule, FooModule],
+      imports: [AopModule, FooModule, BazModule],
     }).compile();
 
     const app = module.createNestApplication(new FastifyAdapter());
@@ -70,7 +87,7 @@ describe('AopModule', () => {
    */
   it('decorated function should have "name" property', async () => {
     const module = await Test.createTestingModule({
-      imports: [AopModule, FooModule],
+      imports: [AopModule, FooModule, BazModule],
     }).compile();
     const app = module.createNestApplication(new FastifyAdapter());
     await app.init();
@@ -82,39 +99,52 @@ describe('AopModule', () => {
     expect(fooService.multipleDecorated.name).toStrictEqual('multipleDecorated');
     expect(fooService.thisTest.name).toStrictEqual('thisTest');
     expect(fooController.getFoo.name).toStrictEqual('getFoo');
+
+    const bazService = await app.resolve(BazService);
+
+    expect(bazService.baz.name).toStrictEqual('baz');
+    expect(bazService.thisTest.name).toStrictEqual('thisTest');
   });
 
   describe('this of the decorated function must be this', () => {
     it('With AopModule', async () => {
       const module = await Test.createTestingModule({
-        imports: [AopModule, FooModule],
+        imports: [AopModule, FooModule, BazModule],
       }).compile();
 
       const app = module.createNestApplication(new FastifyAdapter());
       await app.init();
-      const fooService = app.get(FooService);
+      const fooService = app.get(FooService),
+        bazService = await app.resolve(BazService);
 
       fooService.thisTest();
       expect(fooThisValue).toBe(fooService);
+
+      bazService.thisTest();
+      expect(bazThisValue).toBe(bazService);
     });
 
     it('Without AopModule', async () => {
       const module = await Test.createTestingModule({
-        imports: [BarModule],
+        imports: [BarModule, BazModule],
       }).compile();
 
       const app = module.createNestApplication(new FastifyAdapter());
       await app.init();
-      const barService = app.get(BarService);
+      const barService = app.get(BarService),
+        bazService = await app.resolve(BazService);
 
       barService.thisTest();
       expect(barThisValue).toBe(barService);
+
+      bazService.thisTest();
+      expect(bazThisValue).toBe(bazService);
     });
   });
 
   it('Each instance should have its dependencies applied correctly', async () => {
     const module = await Test.createTestingModule({
-      imports: [AopModule, FooModule],
+      imports: [AopModule, FooModule, BazModule],
     }).compile();
 
     const app = module.createNestApplication(new FastifyAdapter());
@@ -122,9 +152,13 @@ describe('AopModule', () => {
 
     const duplicateService1: DuplicateService = app.get('DUPLICATE_1');
     const duplicateService2: DuplicateService = app.get('DUPLICATE_2');
+    const duplicateService3: DuplicateService = await app.resolve('DUPLICATE_3');
+    const duplicateService4: DuplicateService = await app.resolve('DUPLICATE_4');
 
     expect(duplicateService1.getValue()).toMatchInlineSnapshot(`"1:dependency_value"`);
     expect(duplicateService2.getValue()).toMatchInlineSnapshot(`"2:dependency_value"`);
+    expect(duplicateService3.getValue()).toMatchInlineSnapshot(`"3:dependency_value"`);
+    expect(duplicateService4.getValue()).toMatchInlineSnapshot(`"4:dependency_value"`);
   });
 
   it('AopDecorator created using useFactory should also be functional', async () => {
@@ -135,8 +169,14 @@ describe('AopModule', () => {
     const app = module.createNestApplication(new FastifyAdapter());
     await app.init();
 
-    const aopFactoryService: AopFactoryService = app.get(AopFactoryService);
+    const aopFactoryService: AopFactoryService = app.get(AopFactoryService),
+      aopFactoryRequestScopedService: AopFactoryService = await app.resolve(
+        'AopFactoryRequestScopedService',
+      );
 
     expect(aopFactoryService.getValue('params')).toMatchInlineSnapshot(`"params:dependency_1"`);
+    expect(aopFactoryRequestScopedService.getValue('params')).toMatchInlineSnapshot(
+      `"params:dependency_1"`,
+    );
   });
 });

--- a/src/__test__/controller.test.ts
+++ b/src/__test__/controller.test.ts
@@ -5,6 +5,7 @@ import supertest from 'supertest';
 import { AopModule } from '../aop.module';
 import { CacheModule } from './fixture/cache';
 import { FooController, FooModule } from './fixture/foo';
+import { BazModule } from './fixture/baz';
 
 describe('Controller', () => {
   let app: INestApplication;
@@ -12,7 +13,7 @@ describe('Controller', () => {
 
   beforeAll(async () => {
     moduleRef = await Test.createTestingModule({
-      imports: [AopModule, FooModule, CacheModule],
+      imports: [AopModule, FooModule, CacheModule, BazModule],
     }).compile();
 
     app = moduleRef.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
@@ -37,6 +38,13 @@ describe('Controller', () => {
     await requester.get('/foo').query({ id: 3 }).expect(200).expect('foo3');
 
     expect(fooController.getFooCount).toMatchInlineSnapshot(`3`);
+  });
+
+  it('With Baz Decorator applied, BazService method return request url included string properly', async () => {
+    const requester = supertest(app.getHttpServer());
+    const result = (await requester.get('/baz')).text;
+
+    expect(result).toMatchInlineSnapshot(`"/baz:dependency_0"`);
   });
 
   afterAll(async () => await app.close());

--- a/src/__test__/fixture/aop-factory/aop-factory.module.ts
+++ b/src/__test__/fixture/aop-factory/aop-factory.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, Scope } from '@nestjs/common';
 import { SampleModule } from '../sample';
 
 import { SampleService } from '../sample/sample.service';
@@ -13,6 +13,11 @@ import { AopFactoryService } from './aop-factory.service';
       provide: AopFactoryDecorator,
       inject: [SampleService],
       useFactory: (sampleService: SampleService) => new AopFactoryDecorator(sampleService),
+    },
+    {
+      provide: 'AopFactoryRequestScopedService',
+      scope: Scope.REQUEST,
+      useClass: AopFactoryService,
     },
   ],
   exports: [AopFactoryService],

--- a/src/__test__/fixture/baz/baz.controller.ts
+++ b/src/__test__/fixture/baz/baz.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get } from '@nestjs/common';
+import { BazService } from './baz.service';
+import { Baz } from './baz.decorator';
+
+@Controller()
+export class BazController {
+  constructor(private readonly bazService: BazService) {}
+
+  @Get('baz')
+  @Baz({ options: '0' })
+  getUrl() {
+    return this.bazService.getUrl();
+  }
+}

--- a/src/__test__/fixture/baz/baz.decorator.ts
+++ b/src/__test__/fixture/baz/baz.decorator.ts
@@ -13,13 +13,19 @@ export const Baz = (options: BazOptions) => createDecorator(BAZ, options);
 
 @Aspect(BAZ)
 export class BazDecorator implements LazyDecorator {
+  private wrapCalledCnt = 0;
   constructor(private readonly sampleService: SampleService) {}
   wrap({ method, metadata: options }: WrapParams<any, BazOptions>) {
+    this.wrapCalledCnt++;
     return (...args: any[]) => {
       const originResult = method(...args);
       const sample = this.sampleService.sample();
 
       return originResult + ':' + sample + '_' + options.options;
     };
+  }
+
+  getWrapCalledCnt() {
+    return this.wrapCalledCnt;
   }
 }

--- a/src/__test__/fixture/baz/baz.decorator.ts
+++ b/src/__test__/fixture/baz/baz.decorator.ts
@@ -1,0 +1,25 @@
+import { LazyDecorator, WrapParams } from '../../../lazy-decorator';
+import { Aspect } from '../../../aspect';
+import { createDecorator } from '../../../create-decorator';
+import { SampleService } from '../sample';
+
+export const BAZ = Symbol('BAZ');
+
+type BazOptions = {
+  options: string;
+};
+
+export const Baz = (options: BazOptions) => createDecorator(BAZ, options);
+
+@Aspect(BAZ)
+export class BazDecorator implements LazyDecorator {
+  constructor(private readonly sampleService: SampleService) {}
+  wrap({ method, metadata: options }: WrapParams<any, BazOptions>) {
+    return (...args: any[]) => {
+      const originResult = method(...args);
+      const sample = this.sampleService.sample();
+
+      return originResult + ':' + sample + '_' + options.options;
+    };
+  }
+}

--- a/src/__test__/fixture/baz/baz.module.ts
+++ b/src/__test__/fixture/baz/baz.module.ts
@@ -1,0 +1,26 @@
+import { Module, Scope } from '@nestjs/common';
+import { BazDecorator } from './baz.decorator';
+import { BazService } from './baz.service';
+import { BazController } from './baz.controller';
+import { SampleModule } from '../sample';
+import { DuplicateService } from './duplicate.service';
+
+@Module({
+  imports: [SampleModule],
+  controllers: [BazController],
+  providers: [
+    BazDecorator,
+    BazService,
+    {
+      provide: 'DUPLICATE_3',
+      scope: Scope.REQUEST,
+      useValue: new DuplicateService(3),
+    },
+    {
+      provide: 'DUPLICATE_4',
+      scope: Scope.REQUEST,
+      useValue: new DuplicateService(4),
+    },
+  ],
+})
+export class BazModule {}

--- a/src/__test__/fixture/baz/baz.module.ts
+++ b/src/__test__/fixture/baz/baz.module.ts
@@ -1,6 +1,6 @@
 import { Module, Scope } from '@nestjs/common';
 import { BazDecorator } from './baz.decorator';
-import { BazService } from './baz.service';
+import { BazService, StaticBazService } from './baz.service';
 import { BazController } from './baz.controller';
 import { SampleModule } from '../sample';
 import { DuplicateService } from './duplicate.service';
@@ -21,6 +21,7 @@ import { DuplicateService } from './duplicate.service';
       scope: Scope.REQUEST,
       useValue: new DuplicateService(4),
     },
+    StaticBazService,
   ],
 })
 export class BazModule {}

--- a/src/__test__/fixture/baz/baz.service.ts
+++ b/src/__test__/fixture/baz/baz.service.ts
@@ -1,0 +1,27 @@
+import { Inject, Injectable, Scope } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { SetOriginalTrue } from '../foo/foo.decorator';
+import { Baz } from './baz.decorator';
+
+@Injectable({ scope: Scope.REQUEST })
+export class BazService {
+  constructor(@Inject(REQUEST) private readonly request: any) {}
+
+  getUrl() {
+    return this.request.url;
+  }
+
+  @Baz({ options: 'options' })
+  @SetOriginalTrue()
+  baz(arg1: string, arg2: number) {
+    return arg1 + arg2;
+  }
+
+  @Baz({ options: '0' })
+  thisTest() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    bazThisValue = this;
+  }
+}
+
+export let bazThisValue: any;

--- a/src/__test__/fixture/baz/baz.service.ts
+++ b/src/__test__/fixture/baz/baz.service.ts
@@ -22,6 +22,31 @@ export class BazService {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     bazThisValue = this;
   }
+
+  @Baz({ options: '0' })
+  bazOnce() {
+    return 'once';
+  }
+
+  @Baz({ options: '0' })
+  @Baz({ options: '1' })
+  bazTwice() {
+    return 'twice';
+  }
 }
 
 export let bazThisValue: any;
+
+@Injectable()
+export class StaticBazService {
+  @Baz({ options: '0' })
+  bazOnce() {
+    return 'once';
+  }
+
+  @Baz({ options: '0' })
+  @Baz({ options: '1' })
+  bazTwice() {
+    return 'twice';
+  }
+}

--- a/src/__test__/fixture/baz/duplicate.service.ts
+++ b/src/__test__/fixture/baz/duplicate.service.ts
@@ -1,0 +1,12 @@
+import { Injectable, Scope } from '@nestjs/common';
+import { Baz } from './baz.decorator';
+
+@Injectable({ scope: Scope.REQUEST })
+export class DuplicateService {
+  constructor(private readonly value: number) {}
+
+  @Baz({ options: 'value' })
+  getValue() {
+    return this.value;
+  }
+}

--- a/src/__test__/fixture/baz/index.ts
+++ b/src/__test__/fixture/baz/index.ts
@@ -1,0 +1,3 @@
+export * from './baz.decorator';
+export * from './baz.service';
+export * from './baz.module';

--- a/src/auto-aspect-executor.ts
+++ b/src/auto-aspect-executor.ts
@@ -15,7 +15,7 @@ export class AutoAspectExecutor implements OnModuleInit {
     private readonly reflector: Reflector,
   ) {}
 
-  onModuleInit() {
+  async onModuleInit() {
     const controllers = this.discoveryService.getControllers();
     const providers = this.discoveryService.getProviders();
 
@@ -24,16 +24,19 @@ export class AutoAspectExecutor implements OnModuleInit {
       return;
     }
 
-    const singletonWrapper = providers
+    const instanceWrappers = providers
       .concat(controllers)
       .filter(({ instance }) => instance && Object.getPrototypeOf(instance));
 
-    for (const wrapper of singletonWrapper) {
-      const { instance } = wrapper;
+    for (const wrapper of instanceWrappers) {
+      const target = wrapper.isDependencyTreeStatic()
+        ? wrapper.instance
+        : wrapper.metatype.prototype;
+
       // Use scanFromPrototype for support nestjs 8
       const methodNames = this.metadataScanner.scanFromPrototype(
-        instance,
-        Object.getPrototypeOf(instance),
+        target,
+        wrapper.isDependencyTreeStatic() ? Object.getPrototypeOf(target) : target,
         (name) => name,
       );
 
@@ -45,33 +48,26 @@ export class AutoAspectExecutor implements OnModuleInit {
             originalFn: any;
             metadata?: unknown;
             aopSymbol: symbol;
-          }[] = this.reflector.get(metadataKey, instance[methodName]);
+          }[] = this.reflector.get(metadataKey, target[methodName]);
           if (!metadataList) {
             return;
           }
 
-          // TODO: Support request scope providers
-          if (!wrapper.isDependencyTreeStatic()) {
-            console.warn(
-              `[${
-                wrapper.instance?.constructor?.name || 'Unknown'
-              }] "@tossteam/nestjs-aop" does not yet support request scope providers`,
-            );
-            return;
-          }
-
           for (const { originalFn, metadata, aopSymbol } of metadataList) {
-            const wrappedMethod = lazyDecorator.wrap({
-              instance,
-              methodName,
-              method: originalFn.bind(instance),
-              metadata,
+            const proxy = new Proxy(target[methodName], {
+              apply: (_, thisArg, args) => {
+                const wrappedMethod = lazyDecorator.wrap({
+                  instance: thisArg,
+                  methodName,
+                  method: originalFn.bind(thisArg),
+                  metadata,
+                });
+                return Reflect.apply(wrappedMethod, lazyDecorator, args);
+              },
             });
 
-            Object.setPrototypeOf(wrappedMethod, instance[methodName]);
-
-            instance[aopSymbol] ??= {};
-            instance[aopSymbol][methodName] = wrappedMethod;
+            target[aopSymbol] ??= {};
+            target[aopSymbol][methodName] = proxy;
           }
         });
       }

--- a/src/auto-aspect-executor.ts
+++ b/src/auto-aspect-executor.ts
@@ -16,7 +16,7 @@ export class AutoAspectExecutor implements OnModuleInit {
     private readonly reflector: Reflector,
   ) {}
 
-  async onModuleInit() {
+  onModuleInit() {
     const controllers = this.discoveryService.getControllers();
     const providers = this.discoveryService.getProviders();
 
@@ -70,7 +70,7 @@ export class AutoAspectExecutor implements OnModuleInit {
                 cached[aopSymbol] ??= {};
                 cached[aopSymbol][methodName] = wrappedMethod;
                 this.wrappedMethodCache.set(thisArg, cached);
-                return Reflect.apply(wrappedMethod, lazyDecorator, args);
+                return Reflect.apply(wrappedMethod, thisArg, args);
               },
             });
 


### PR DESCRIPTION
## Overview

As request scoped providers and controllers are not supported, I added that.
In nest, request scoped instance wrappers uses their metatype when they instantiated, so modifying prototype of request scoped wrapper's metatype can modify the instantiated object's behavior. 

reference: https://github.com/nestjs/nest/blob/67d4656623c7dc50f2cfd8d5e963678bcbf77959/packages/core/injector/injector.ts#L745-L757

I also changed applying aop wrapped function to original function by using ecma [proxy](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Proxy), because wrapped function must bind request scoped wrapper's instance to original function' this object.. but when `onModuleInit` time, request did not arrived so aop executor can't access to instance of request scoped wrapper. Using proxy object can access the original function's this binding, and also proxy object deliver all of other stuffs(property access, other things..) to original function so it seems great for this usecase. 

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/nestjs-aop/blob/main/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
