### PR TITLE
feat: Add 'init' into 'LazyDecorator' for providing metadata to decorated target when 'onModuleInit()'.

### DIFF
--- a/src/__test__/fixture/aop-testing.decorator.ts
+++ b/src/__test__/fixture/aop-testing.decorator.ts
@@ -1,10 +1,11 @@
 import { Aspect } from '../../aspect';
 import { createDecorator } from '../../create-decorator';
-import { LazyDecorator, WrapParams } from '../../lazy-decorator';
+import { InitParams, LazyDecorator, WrapParams } from '../../lazy-decorator';
 
 export const AOP_TESTING = Symbol('AOP_TESTING');
 
 type AopTestingOptions = {
+  initializingValue?: boolean;
   callback?: (params: {
     args: any[];
     wrapParams: WrapParams<any, AopTestingOptions>;
@@ -25,6 +26,12 @@ export class AopTestingDecorator implements LazyDecorator {
 
   constructor(...dependencies: any[]) {
     this.dependencies = dependencies;
+  }
+
+  init(params: InitParams<any, AopTestingOptions>) {
+    if (params.metadata.initializingValue) {
+      Reflect.defineMetadata('initializingValue', true, params.unboundMethod);
+    }
   }
 
   wrap(params: WrapParams<any, AopTestingOptions>) {

--- a/src/lazy-decorator.ts
+++ b/src/lazy-decorator.ts
@@ -1,14 +1,25 @@
 /* eslint-disable @typescript-eslint/ban-types */
-export type WrapParams<T extends Function = Function, M = unknown> = {
+export type GenericParams<M = unknown> = {
   instance: any;
   methodName: string;
-  method: T;
   metadata: M;
 };
 
+export type InitParams<T extends Function = Function, M = unknown> = 
+  GenericParams<M> & {unboundMethod: T;}; 
+
+/* The extending parameter's name must be 'boundMethod', but kept its name for backward-compatibility. */
+export type WrapParams<T extends Function = Function, M = unknown> =
+  GenericParams<M> & {method: T;};
+
 /**
  * Aspect 선언시 구현이 필요합니다.
+ *
+ * @interface LazyDecorator
+ * @member init is used for setting metadata or performing other initializations before the wrapped method has been called.
+ * @member wrap is used for wrapping decorated method with advice logic.
  */
 export interface LazyDecorator<T extends Function = Function, M = unknown> {
+  init?(params: InitParams<T, M>): void;
   wrap(params: WrapParams<T, M>): T;
 }


### PR DESCRIPTION
## Overview
I found a limitation of the `wrap` method of `LazyDecorator`; advice logic can only be triggered by calling the decorated method.
I wanted to reference the metadata of the decorated method in `NestInterceptor` but couldn't get the correct metadata value even with reflection until the method was first called.
I implemented an additional prototype, `init` for `LazyDecorator`, called when `AopModule` is initialized.

## PR Checklist
- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/nestjs-aop/blob/main/CONTRIBUTING.md)
2. I have written documents and tests, if needed.