### PR TITLE
fix: remove fake-esm build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v4
         with:
           version: 8
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup pnpm
-      - uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v4
         with:
           version: 8
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "2.1.6",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "module": "esm/index.js",
   "license": "MIT",
   "engines": {
     "node": ">=16",
@@ -11,10 +10,9 @@
   },
   "scripts": {
     "test": "jest --maxWorkers 4",
-    "build": "rm -rf dist esm && tsc -p tsconfig.build.json && tsc -p tsconfig.esm.json"
+    "build": "rm -rf dist && tsc -p tsconfig.build.json"
   },
   "files": [
-    "esm",
     "dist",
     "src"
   ],

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "esm",
-    "module": "esnext"
-  }
-}


### PR DESCRIPTION
## Overview
Since `"module": "esnext"` cannot interopable with Pure ESM, It prevent pure ESM codebase from loading proper javascript file. 

<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/nestjs-aop/blob/main/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
