### PR TITLE
docs: add caveat about calling "init" when using TestingModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ English | [한국어](https://github.com/toss/nestjs-aop/blob/v2.x/readme_kr.md)
   <ol>
     <li><a href="#installation">Installation</a></li>
     <li><a href="#usage">Usage</a></li>
+    <li><a href="#caveats">Caveats</a></li>
     <li><a href="#references">References</a></li>
     <li><a href="#contributing">Contributing</a></li>
     <li><a href="#license">License</a></li>
@@ -108,6 +109,21 @@ export class SomeService {
     // ...
   }
 }
+```
+
+
+<!-- CAVEATS -->
+## Caveats
+If you’re testing with NestJS’s TestingModule, don’t forget to call the init method.
+
+```typescript
+import { Test } from '@nestjs/testing';
+
+const module = await Test.createTestingModule({
+  // ...
+}).compile();
+
+await module.init();
 ```
 
 

--- a/readme_kr.md
+++ b/readme_kr.md
@@ -23,6 +23,7 @@
   <ol>
     <li><a href="#설치 방법">설치 방법</a></li>
     <li><a href="#사용 예시">사용 예시</a></li>
+    <li><a href="#주의사항">주의사항</a></li>
     <li><a href="#참고자료">참고자료</a></li>
     <li><a href="#기여하기">기여하기</a></li>
     <li><a href="#라이센스">라이센스</a></li>
@@ -107,6 +108,21 @@ export class SomeService {
     // ...
   }
 }
+```
+
+
+<!-- 주의사항 -->
+## 주의사항
+NestJS의 `TestingModule`을 이용해 테스트할 경우 init 메소드 호출이 필요합니다.
+
+```typescript
+import { Test } from '@nestjs/testing';
+
+const module = await Test.createTestingModule({
+  // ...
+}).compile();
+
+await module.init();
 ```
 
 


### PR DESCRIPTION
## Overview

I thought it would be helpful to add a note that when writing tests using NestJS’s TestingModule, you need to call the init method.
Developers who aren’t familiar with the internal implementation of this package might not realize that the Nest application needs to be fully bootstrapped for things to work properly — just like I didn’t at first. 😅

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/nestjs-aop/blob/main/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
