### PR TITLE
docs: translate Korean JSDoc comments to English and fix typo in createDecorator

### DIFF
--- a/src/auto-aspect-executor.ts
+++ b/src/auto-aspect-executor.ts
@@ -6,7 +6,8 @@ import { AopMetadata } from './core/types';
 import { LazyDecorator } from './lazy-decorator';
 
 /**
- * Aspect 가 선언되어 있고 LazyDecorator 가 구현되어 있는 provider 가 있는 경우 ioc 에 등록된 모든 provider 를 순회하면서 LazyDecorator 를 적용함.
+ * If there are providers that have @Aspect declared and implement LazyDecorator,
+ * iterate through all providers registered in the IoC container and apply LazyDecorator to each.
  */
 @Injectable()
 export class AutoAspectExecutor implements OnModuleInit {

--- a/src/create-decorator.ts
+++ b/src/create-decorator.ts
@@ -4,7 +4,7 @@ import { AddMetadata } from './utils';
 
 /**
  * @param metadataKey equal to 1st argument of Aspect Decorator
- * @param metadata The value corresponding to the metadata of WrapParams. It can be obtained from LazyDecorator's warp method and used.
+ * @param metadata The value corresponding to the metadata of WrapParams. It can be obtained from LazyDecorator's wrap method and used.
  */
 export const createDecorator = (
   metadataKey: symbol | string,

--- a/src/lazy-decorator.ts
+++ b/src/lazy-decorator.ts
@@ -7,7 +7,8 @@ export type WrapParams<T extends Function = Function, M = unknown> = {
 };
 
 /**
- * Aspect 선언시 구현이 필요합니다.
+ * Must be implemented when declaring an Aspect.
+ * @see Aspect
  */
 export interface LazyDecorator<T extends Function = Function, M = unknown> {
   wrap(params: WrapParams<T, M>): T;


### PR DESCRIPTION
## Overview
Translated comments in `AutoAspectExecutor` and `LazyDecorator` to English for consistency with the rest of the codebase, and fixed a typo in `createDecorator`

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/nestjs-aop/blob/main/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
